### PR TITLE
Refactor IPreferences for better null handling

### DIFF
--- a/src/MZikmund.Toolkit.WinUI/Services/IPreferences.cs
+++ b/src/MZikmund.Toolkit.WinUI/Services/IPreferences.cs
@@ -12,6 +12,16 @@ public interface IPreferences
     /// </summary>
     /// <typeparam name="T">Type.</typeparam>
     /// <param name="key">Key.</param>
+    /// <param name="defaultValue">Default value.</param>
+    /// <returns>Value from settings or default value.</returns>
+    /// </summary>
+    T Get<T>(string key, T defaultValue);
+
+    /// <summary>
+    /// Retrieves a plain setting from the preferences.
+    /// </summary>
+    /// <typeparam name="T">Type.</typeparam>
+    /// <param name="key">Key.</param>
     /// <param name="value">Value.</param>
     /// <returns>Value from settings or default value.</returns>
     bool TryGet<T>(string key, [MaybeNullWhen(false)] out T value);
@@ -23,6 +33,16 @@ public interface IPreferences
     /// <param name="key">Key.</param>
     /// <param name="value">Value.</param>
     void Set<T>(string key, T? value);
+
+    /// <summary>
+    /// Retrieves a complex setting from the preferences.
+    /// </summary>
+    /// <typeparam name="T">Type.</typeparam>
+    /// <param name="key">Key.</param>
+    /// <param name="defaultValue">Default value.</param>
+    /// <returns>Value from settings or default value.</returns>
+    /// </summary>
+    T GetComplex<T>(string key, T defaultValue);
 
     /// <summary>
     /// Gets a complex setting from the preferences.

--- a/src/MZikmund.Toolkit.WinUI/Services/IPreferences.cs
+++ b/src/MZikmund.Toolkit.WinUI/Services/IPreferences.cs
@@ -1,4 +1,6 @@
-﻿namespace MZikmund.Toolkit.WinUI.Services;
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace MZikmund.Toolkit.WinUI.Services;
 
 /// <summary>
 /// Handles application preferences.
@@ -10,9 +12,9 @@ public interface IPreferences
     /// </summary>
     /// <typeparam name="T">Type.</typeparam>
     /// <param name="key">Key.</param>
-    /// <param name="defaultValue">Default value.</param>
+    /// <param name="value">Value.</param>
     /// <returns>Value from settings or default value.</returns>
-    T Get<T>(string key, T defaultValue);
+    bool TryGet<T>(string key, [MaybeNullWhen(false)] out T value);
 
     /// <summary>
     /// Sets a plain setting in the preferences.
@@ -28,8 +30,9 @@ public interface IPreferences
     /// </summary>
     /// <typeparam name="T">Type.</typeparam>
     /// <param name="key">Key.</param>
+    /// <param name="value">Value.</param>
     /// <returns>Complex setting.</returns>
-    T? GetComplex<T>(string key);
+    bool TryGetComplex<T>(string key, [MaybeNullWhen(false)] out T value);
 
     /// <summary>
     /// Sets a complex setting in the preferences.

--- a/src/MZikmund.Toolkit.WinUI/Services/Preferences.cs
+++ b/src/MZikmund.Toolkit.WinUI/Services/Preferences.cs
@@ -17,27 +17,25 @@ public class Preferences : IPreferences
     /// </summary>
     /// <typeparam name="T">Type.</typeparam>
     /// <param name="key">Key.</param>
-    /// <param name="defaultValue">Default value.</param>
+    /// <param name="value">Value.</param>
     /// <returns>Value from settings or default value.</returns>
-    public T Get<T>(string key, T defaultValue)
+    public bool TryGet<T>(string key, [MaybeNullWhen(false)] out T value)
     {
         if (TryGetFromCache<T>(key, out var cachedValue))
         {
-            return cachedValue;
+            value = cachedValue;
+            return true;
         }
 
-        if (TryGetFromContainer<T>(key, out var value) && value is { })
+        if (TryGetFromContainer<T>(key, out var containerValue) && containerValue is { })
         {
-            _preferenceCache[key] = value;
-            return value;
+            _preferenceCache[key] = containerValue;
+            value = containerValue;
+            return true;
         }
 
-        if (defaultValue is { })
-        {
-            _preferenceCache[key] = defaultValue;
-        }
-
-        return defaultValue;
+        value = default;
+        return false;
     }
 
     /// <summary>
@@ -46,25 +44,29 @@ public class Preferences : IPreferences
     /// </summary>
     /// <typeparam name="T">Type.</typeparam>
     /// <param name="key">Key.</param>
+    /// <param name="value">Value.</param>
     /// <returns>Complex setting.</returns>
-    public T? GetComplex<T>(string key)
+    public bool TryGetComplex<T>(string key, [MaybeNullWhen(false)] out T value)
     {
         if (TryGetFromCache<T>(key, out var cachedValue))
         {
-            return cachedValue;
+            value = cachedValue;
+            return true;
         }
 
-        if (TryGetFromContainer<string>(key, out var value))
+        if (TryGetFromContainer<string>(key, out var containerValue) && containerValue is not null)
         {
-            var deserializedValue = JsonSerializer.Deserialize<T>(value);
+            var deserializedValue = JsonSerializer.Deserialize<T>(containerValue);
             if (deserializedValue is { })
             {
                 _preferenceCache[key] = deserializedValue;
+                value = deserializedValue;
+                return true;
             }
-            return deserializedValue;
         }
 
-        return default;
+        value = default;
+        return false;
     }
 
     /// <summary>

--- a/src/MZikmund.Toolkit.WinUI/Services/Preferences.cs
+++ b/src/MZikmund.Toolkit.WinUI/Services/Preferences.cs
@@ -145,4 +145,26 @@ public class Preferences : IPreferences
         value = default;
         return false;
     }
+
+    /// <summary>
+    /// Retrieves a plain setting from the preferences.
+    /// </summary>
+    /// <typeparam name="T">Type.</typeparam>
+    /// <param name="key">Key.</param>
+    /// <param name="defaultValue">Default value.</param>
+    /// <returns>Value from settings or default value.</returns>
+    /// </summary>
+    public T Get<T>(string key, T defaultValue) => TryGet<T>(key, out var value) ?
+        value : defaultValue;
+
+    /// <summary>
+    /// Retrieves a complex setting from the preferences.
+    /// </summary>
+    /// <typeparam name="T">Type.</typeparam>
+    /// <param name="key">Key.</param>
+    /// <param name="defaultValue">Default value.</param>
+    /// <returns>Value from settings or default value.</returns>
+    /// </summary>
+    public T GetComplex<T>(string key, T defaultValue) => TryGetComplex<T>(key, out var value) ?
+        value : defaultValue;
 }


### PR DESCRIPTION
- Added `using System.Diagnostics.CodeAnalysis;` in `IPreferences.cs` for nullability attributes.
- Replaced `Get<T>` and `GetComplex<T>` in `IPreferences` with `TryGet<T>` and `TryGetComplex<T>`, respectively, introducing a boolean return type and an `out` parameter marked with `[MaybeNullWhen(false)]`. This change enhances method contracts for nullability and failure handling.
- Updated `Preferences` class implementations to align with the new interface, ensuring consistency in nullability handling and method signatures.
- The shift to `TryGet` methods improves API robustness, making it clearer when methods fail to retrieve a value and how nullability is handled, thereby aiding in preventing null reference errors.