### PR TITLE
feat: Add StableHash helper for Guid/string to int

### DIFF
--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/HomePage.xaml
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/HomePage.xaml
@@ -40,6 +40,12 @@
           <Run Text="ObservableCollection Merge:" FontWeight="SemiBold" />
           <Run Text=" MergeWith extension that synchronizes an ObservableCollection with a source list using minimal Insert/RemoveAt/Move operations." />
         </TextBlock>
+
+        <TextBlock Style="{ThemeResource BodyTextBlockStyle}">
+          <Run Text="• " FontWeight="Bold" />
+          <Run Text="Stable Hash:" FontWeight="SemiBold" />
+          <Run Text=" StableHash helper that produces a stable Int32 from a Guid or string for platform APIs that require integer IDs." />
+        </TextBlock>
         
         <TextBlock Style="{ThemeResource BodyTextBlockStyle}">
           <Run Text="• " FontWeight="Bold" />

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/StableHashSamplePage.xaml
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/StableHashSamplePage.xaml
@@ -1,0 +1,81 @@
+<Page x:Class="MZikmund.Toolkit.Sample.StableHashSamplePage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:local="using:MZikmund.Toolkit.Sample">
+
+  <ScrollViewer Padding="24">
+    <StackPanel Spacing="16" MaxWidth="800">
+      <TextBlock Text="StableHash Helper"
+                 Style="{ThemeResource TitleTextBlockStyle}" />
+
+      <TextBlock Text="StableHash produces a stable Int32 from a Guid or string by XOR-ing the underlying bytes. Useful when a platform API demands an int ID (notifications, alarms) but your domain key is a string or Guid."
+                 TextWrapping="Wrap"
+                 Style="{ThemeResource BodyTextBlockStyle}" />
+
+      <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+              BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+              BorderThickness="1"
+              CornerRadius="8"
+              Padding="16">
+        <StackPanel Spacing="12">
+          <TextBlock Text="GUID → int"
+                     Style="{ThemeResource SubtitleTextBlockStyle}" />
+
+          <TextBox x:Name="GuidInput"
+                   Header="GUID"
+                   PlaceholderText="00000000-0000-0000-0000-000000000000" />
+
+          <StackPanel Orientation="Horizontal" Spacing="8">
+            <Button Content="Hash" Click="HashGuid_Click" Style="{ThemeResource AccentButtonStyle}" />
+            <Button Content="New random GUID" Click="NewGuid_Click" />
+          </StackPanel>
+
+          <TextBlock x:Name="GuidResult"
+                     Text="No result yet"
+                     Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}" />
+        </StackPanel>
+      </Border>
+
+      <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+              BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+              BorderThickness="1"
+              CornerRadius="8"
+              Padding="16">
+        <StackPanel Spacing="12">
+          <TextBlock Text="String → int"
+                     Style="{ThemeResource SubtitleTextBlockStyle}" />
+
+          <TextBox x:Name="StringInput"
+                   Header="String"
+                   PlaceholderText="Type any string" />
+
+          <Button Content="Hash" Click="HashString_Click" Style="{ThemeResource AccentButtonStyle}" />
+
+          <TextBlock x:Name="StringResult"
+                     Text="No result yet"
+                     Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}" />
+        </StackPanel>
+      </Border>
+
+      <Border Background="{ThemeResource LayerFillColorDefaultBrush}"
+              BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+              BorderThickness="1"
+              CornerRadius="8"
+              Padding="16">
+        <StackPanel Spacing="8">
+          <TextBlock Text="Code Sample"
+                     Style="{ThemeResource SubtitleTextBlockStyle}" />
+
+          <TextBlock FontFamily="Consolas" TextWrapping="Wrap">
+            <Run>using MZikmund.Toolkit.WinUI.Helpers;</Run><LineBreak />
+            <LineBreak />
+            <Run>// Same Guid -> same int, every run, every process.</Run><LineBreak />
+            <Run>int notificationId = StableHash.FromGuid(reminder.Id);</Run><LineBreak />
+            <LineBreak />
+            <Run>int alarmId = StableHash.FromString(eventKey);</Run>
+          </TextBlock>
+        </StackPanel>
+      </Border>
+    </StackPanel>
+  </ScrollViewer>
+</Page>

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/StableHashSamplePage.xaml.cs
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/StableHashSamplePage.xaml.cs
@@ -1,0 +1,39 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using MZikmund.Toolkit.WinUI.Helpers;
+
+namespace MZikmund.Toolkit.Sample;
+
+public sealed partial class StableHashSamplePage : Page
+{
+    public StableHashSamplePage()
+    {
+        this.InitializeComponent();
+        GuidInput.Text = Guid.NewGuid().ToString();
+    }
+
+    private void HashGuid_Click(object sender, RoutedEventArgs e)
+    {
+        if (Guid.TryParse(GuidInput.Text, out var guid))
+        {
+            var hash = StableHash.FromGuid(guid);
+            GuidResult.Text = $"FromGuid({guid:D}) = {hash} (0x{hash:X8})";
+        }
+        else
+        {
+            GuidResult.Text = "Not a valid GUID.";
+        }
+    }
+
+    private void NewGuid_Click(object sender, RoutedEventArgs e)
+    {
+        GuidInput.Text = Guid.NewGuid().ToString();
+    }
+
+    private void HashString_Click(object sender, RoutedEventArgs e)
+    {
+        var input = StringInput.Text ?? string.Empty;
+        var hash = StableHash.FromString(input);
+        StringResult.Text = $"FromString(\"{input}\") = {hash} (0x{hash:X8})";
+    }
+}

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml
@@ -18,6 +18,8 @@
       <NavigationViewItemHeader Content="Extensions" />
       <NavigationViewItem Content="Package Version" Tag="PackageVersion" Icon="Document" />
       <NavigationViewItem Content="ObservableCollection Merge" Tag="ObservableCollectionMerge" Icon="List" />
+      <NavigationViewItemHeader Content="Helpers" />
+      <NavigationViewItem Content="Stable Hash" Tag="StableHash" Icon="Tag" />
       <NavigationViewItemHeader Content="Infrastructure" />
       <NavigationViewItem Content="XamlRoot Provider" Tag="XamlRootProvider" Icon="Page" />
     </NavigationView.MenuItems>

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml.cs
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml.cs
@@ -30,6 +30,7 @@ public sealed partial class Shell : Page
                 "DialogCoordinator" => typeof(DialogCoordinatorSamplePage),
                 "PackageVersion" => typeof(PackageVersionSamplePage),
                 "ObservableCollectionMerge" => typeof(ObservableCollectionMergeSamplePage),
+                "StableHash" => typeof(StableHashSamplePage),
                 "XamlRootProvider" => typeof(XamlRootProviderSamplePage),
                 _ => null
             };

--- a/src/MZikmund.Toolkit.WinUI/Helpers/StableHash.cs
+++ b/src/MZikmund.Toolkit.WinUI/Helpers/StableHash.cs
@@ -1,0 +1,64 @@
+using System.Text;
+
+namespace MZikmund.Toolkit.WinUI.Helpers;
+
+/// <summary>
+/// Produces a stable <see cref="int"/> hash for a <see cref="Guid"/> or <see cref="string"/>
+/// by XOR-ing 4-byte chunks of the value. Useful for platform APIs that demand integer IDs
+/// (notification IDs, alarm IDs) when the natural domain key is a string or GUID.
+/// </summary>
+/// <remarks>
+/// Stability is the only contract: the same input always yields the same output across runs
+/// and processes. This is not a cryptographic hash and the int range is small enough that
+/// collisions are expected — callers must tolerate them.
+/// </remarks>
+public static class StableHash
+{
+    /// <summary>
+    /// Computes a stable 32-bit hash of <paramref name="value"/> by XOR-ing its 16 bytes
+    /// in four 4-byte chunks.
+    /// </summary>
+    /// <param name="value">GUID to hash.</param>
+    /// <returns>Stable integer hash.</returns>
+    public static int FromGuid(Guid value)
+    {
+        Span<byte> bytes = stackalloc byte[16];
+        value.TryWriteBytes(bytes);
+        return BitConverter.ToInt32(bytes[..4])
+             ^ BitConverter.ToInt32(bytes[4..8])
+             ^ BitConverter.ToInt32(bytes[8..12])
+             ^ BitConverter.ToInt32(bytes[12..16]);
+    }
+
+    /// <summary>
+    /// Computes a stable 32-bit hash of <paramref name="value"/> by XOR-ing its UTF-8 bytes
+    /// in 4-byte chunks. A trailing partial chunk is zero-padded before XOR.
+    /// </summary>
+    /// <param name="value">String to hash. <see langword="null"/> and empty strings both hash to 0.</param>
+    /// <returns>Stable integer hash.</returns>
+    public static int FromString(string? value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return 0;
+        }
+
+        var bytes = Encoding.UTF8.GetBytes(value);
+        var result = 0;
+        var i = 0;
+        while (i + 4 <= bytes.Length)
+        {
+            result ^= BitConverter.ToInt32(bytes, i);
+            i += 4;
+        }
+
+        if (i < bytes.Length)
+        {
+            Span<byte> tail = stackalloc byte[4];
+            bytes.AsSpan(i).CopyTo(tail);
+            result ^= BitConverter.ToInt32(tail);
+        }
+
+        return result;
+    }
+}

--- a/tests/MZikmund.Toolkit.WinUI.Tests/StableHashTests.cs
+++ b/tests/MZikmund.Toolkit.WinUI.Tests/StableHashTests.cs
@@ -1,0 +1,98 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MZikmund.Toolkit.WinUI.Helpers;
+
+namespace MZikmund.Toolkit.WinUI.Tests;
+
+[TestClass]
+public class StableHashTests
+{
+    [TestMethod]
+    public void FromGuid_IsDeterministic()
+    {
+        var guid = new Guid("11111111-2222-3333-4444-555555555555");
+
+        var first = StableHash.FromGuid(guid);
+        var second = StableHash.FromGuid(guid);
+
+        Assert.AreEqual(first, second);
+    }
+
+    [TestMethod]
+    public void FromGuid_KnownValue_HasExpectedHash()
+    {
+        var guid = new Guid("11111111-2222-3333-4444-555555555555");
+        var bytes = guid.ToByteArray();
+        var expected = BitConverter.ToInt32(bytes, 0)
+                     ^ BitConverter.ToInt32(bytes, 4)
+                     ^ BitConverter.ToInt32(bytes, 8)
+                     ^ BitConverter.ToInt32(bytes, 12);
+
+        Assert.AreEqual(expected, StableHash.FromGuid(guid));
+    }
+
+    [TestMethod]
+    public void FromGuid_EmptyGuid_ReturnsZero()
+    {
+        Assert.AreEqual(0, StableHash.FromGuid(Guid.Empty));
+    }
+
+    [TestMethod]
+    public void FromGuid_DifferentGuids_GenerallyProduceDifferentHashes()
+    {
+        var a = StableHash.FromGuid(Guid.Parse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"));
+        var b = StableHash.FromGuid(Guid.Parse("11111111-2222-3333-4444-555555555555"));
+
+        Assert.AreNotEqual(a, b);
+    }
+
+    [TestMethod]
+    public void FromString_IsDeterministic()
+    {
+        var first = StableHash.FromString("notification-key");
+        var second = StableHash.FromString("notification-key");
+
+        Assert.AreEqual(first, second);
+    }
+
+    [TestMethod]
+    public void FromString_NullOrEmpty_ReturnsZero()
+    {
+        Assert.AreEqual(0, StableHash.FromString(null));
+        Assert.AreEqual(0, StableHash.FromString(string.Empty));
+    }
+
+    [TestMethod]
+    public void FromString_DifferentInputs_GenerallyProduceDifferentHashes()
+    {
+        Assert.AreNotEqual(
+            StableHash.FromString("alpha"),
+            StableHash.FromString("beta"));
+    }
+
+    [TestMethod]
+    public void FromString_HandlesNonAsciiUtf8()
+    {
+        var first = StableHash.FromString("připomínka");
+        var second = StableHash.FromString("připomínka");
+
+        Assert.AreEqual(first, second);
+        Assert.AreNotEqual(0, first);
+    }
+
+    [TestMethod]
+    public void FromString_LengthNotMultipleOfFour_StillStable()
+    {
+        var first = StableHash.FromString("abc");
+        var second = StableHash.FromString("abc");
+
+        Assert.AreEqual(first, second);
+    }
+
+    [TestMethod]
+    public void FromString_LongInput_StillStable()
+    {
+        var input = new string('x', 10_000);
+
+        Assert.AreEqual(StableHash.FromString(input), StableHash.FromString(input));
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `StableHash` static helper in `MZikmund.Toolkit.WinUI.Helpers` with `FromGuid(Guid)` and `FromString(string?)`. Both produce a deterministic `Int32` by XOR-ing the underlying bytes in 4-byte chunks (UTF-8 for strings, raw bytes for GUIDs). `null`/empty strings hash to 0.
- Useful for platform APIs that require integer IDs (notification IDs, alarm IDs) when the natural domain key is a string or GUID.
- Wires a gallery sample (`StableHashSamplePage`) into Shell + HomePage.
- Adds 10 unit tests in `tests/MZikmund.Toolkit.WinUI.Tests/StableHashTests.cs` covering determinism, empty inputs, distinct inputs, non-ASCII UTF-8, lengths that aren't multiples of four, and long inputs.

Closes #34

> Stacked on top of #56 (the `MergeWith` PR which introduces the consolidated `MZikmund.Toolkit.slnx` and the test project). Rebase on `main` once #56 merges.

## Test plan

- [x] `dotnet build MZikmund.Toolkit.slnx -c Debug` succeeds.
- [x] Test exe reports 24/24 passed (14 prior + 10 new for `StableHash`).
- [ ] Manually exercise the `Stable Hash` sample page on Windows: paste a known GUID, hit Hash twice, confirm the same int. Same for a string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)