### PR TITLE
feat: Add ResourceAccessor for typed App.xaml resource lookup

### DIFF
--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/HomePage.xaml
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/HomePage.xaml
@@ -40,6 +40,12 @@
           <Run Text="ObservableCollection Merge:" FontWeight="SemiBold" />
           <Run Text=" MergeWith extension that synchronizes an ObservableCollection with a source list using minimal Insert/RemoveAt/Move operations." />
         </TextBlock>
+
+        <TextBlock Style="{ThemeResource BodyTextBlockStyle}">
+          <Run Text="• " FontWeight="Bold" />
+          <Run Text="Resource Accessor:" FontWeight="SemiBold" />
+          <Run Text=" Type-safe lookup of resources defined in App.xaml from code-behind, behaviors, and converters." />
+        </TextBlock>
         
         <TextBlock Style="{ThemeResource BodyTextBlockStyle}">
           <Run Text="• " FontWeight="Bold" />

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/ResourceAccessorSamplePage.xaml
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/ResourceAccessorSamplePage.xaml
@@ -1,0 +1,67 @@
+<Page x:Class="MZikmund.Toolkit.Sample.ResourceAccessorSamplePage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:local="using:MZikmund.Toolkit.Sample">
+
+  <ScrollViewer Padding="24">
+    <StackPanel Spacing="16" MaxWidth="800">
+      <TextBlock Text="ResourceAccessor"
+                 Style="{ThemeResource TitleTextBlockStyle}" />
+
+      <TextBlock Text="ResourceAccessor.GetResource&lt;T&gt; and TryGetResource&lt;T&gt; provide type-safe lookup of resources from Application.Current.Resources. Useful in code-behind, behaviors, and converters where {StaticResource} markup isn't available."
+                 TextWrapping="Wrap"
+                 Style="{ThemeResource BodyTextBlockStyle}" />
+
+      <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+              BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+              BorderThickness="1"
+              CornerRadius="8"
+              Padding="16">
+        <StackPanel Spacing="12">
+          <TextBlock Text="Live lookup"
+                     Style="{ThemeResource SubtitleTextBlockStyle}" />
+
+          <TextBox x:Name="ResourceKeyInput"
+                   Header="Resource key"
+                   PlaceholderText="e.g. SystemAccentColor or BodyTextBlockStyle"
+                   Text="SystemAccentColor" />
+
+          <StackPanel Orientation="Horizontal" Spacing="8">
+            <Button Content="Lookup as Color" Click="LookupColor_Click" Style="{ThemeResource AccentButtonStyle}" />
+            <Button Content="Lookup as Brush" Click="LookupBrush_Click" />
+            <Button Content="Lookup as Style" Click="LookupStyle_Click" />
+          </StackPanel>
+
+          <TextBlock x:Name="LookupResult"
+                     TextWrapping="Wrap"
+                     Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}"
+                     Text="No lookup performed yet." />
+        </StackPanel>
+      </Border>
+
+      <Border Background="{ThemeResource LayerFillColorDefaultBrush}"
+              BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+              BorderThickness="1"
+              CornerRadius="8"
+              Padding="16">
+        <StackPanel Spacing="8">
+          <TextBlock Text="Code Sample"
+                     Style="{ThemeResource SubtitleTextBlockStyle}" />
+
+          <TextBlock FontFamily="Consolas" TextWrapping="Wrap">
+            <Run>using MZikmund.Toolkit.WinUI.Resources;</Run><LineBreak />
+            <LineBreak />
+            <Run>// Throws if missing or wrong type — best when the key must exist.</Run><LineBreak />
+            <Run>var brush = ResourceAccessor.GetResource&lt;Brush&gt;("AccentFillColorDefaultBrush");</Run><LineBreak />
+            <LineBreak />
+            <Run>// TryGet variant when the key may legitimately be absent.</Run><LineBreak />
+            <Run>if (ResourceAccessor.TryGetResource&lt;Style&gt;("MyOptionalStyle", out var style))</Run><LineBreak />
+            <Run>{</Run><LineBreak />
+            <Run>    target.Style = style;</Run><LineBreak />
+            <Run>}</Run>
+          </TextBlock>
+        </StackPanel>
+      </Border>
+    </StackPanel>
+  </ScrollViewer>
+</Page>

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/ResourceAccessorSamplePage.xaml.cs
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/ResourceAccessorSamplePage.xaml.cs
@@ -1,0 +1,56 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+using MZikmund.Toolkit.WinUI.Resources;
+using Windows.UI;
+
+namespace MZikmund.Toolkit.Sample;
+
+public sealed partial class ResourceAccessorSamplePage : Page
+{
+    public ResourceAccessorSamplePage()
+    {
+        this.InitializeComponent();
+    }
+
+    private void LookupColor_Click(object sender, RoutedEventArgs e)
+    {
+        Lookup<Color>(value => $"Color {value} (A={value.A}, R={value.R}, G={value.G}, B={value.B})");
+    }
+
+    private void LookupBrush_Click(object sender, RoutedEventArgs e)
+    {
+        Lookup<Brush>(value =>
+        {
+            if (value is SolidColorBrush solid)
+            {
+                return $"SolidColorBrush {solid.Color}";
+            }
+            return $"Brush of type {value.GetType().Name}";
+        });
+    }
+
+    private void LookupStyle_Click(object sender, RoutedEventArgs e)
+    {
+        Lookup<Style>(value => $"Style targeting {value.TargetType?.Name ?? "(none)"}");
+    }
+
+    private void Lookup<T>(Func<T, string> describe)
+    {
+        var key = (ResourceKeyInput.Text ?? string.Empty).Trim();
+        if (string.IsNullOrEmpty(key))
+        {
+            LookupResult.Text = "Enter a resource key first.";
+            return;
+        }
+
+        if (ResourceAccessor.TryGetResource<T>(key, out var value))
+        {
+            LookupResult.Text = $"Found '{key}' as {typeof(T).Name}: {describe(value)}";
+        }
+        else
+        {
+            LookupResult.Text = $"No '{key}' resource of type {typeof(T).Name} was found.";
+        }
+    }
+}

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml
@@ -18,6 +18,8 @@
       <NavigationViewItemHeader Content="Extensions" />
       <NavigationViewItem Content="Package Version" Tag="PackageVersion" Icon="Document" />
       <NavigationViewItem Content="ObservableCollection Merge" Tag="ObservableCollectionMerge" Icon="List" />
+      <NavigationViewItemHeader Content="Resources" />
+      <NavigationViewItem Content="Resource Accessor" Tag="ResourceAccessor" Icon="Library" />
       <NavigationViewItemHeader Content="Infrastructure" />
       <NavigationViewItem Content="XamlRoot Provider" Tag="XamlRootProvider" Icon="Page" />
     </NavigationView.MenuItems>

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml.cs
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml.cs
@@ -30,6 +30,7 @@ public sealed partial class Shell : Page
                 "DialogCoordinator" => typeof(DialogCoordinatorSamplePage),
                 "PackageVersion" => typeof(PackageVersionSamplePage),
                 "ObservableCollectionMerge" => typeof(ObservableCollectionMergeSamplePage),
+                "ResourceAccessor" => typeof(ResourceAccessorSamplePage),
                 "XamlRootProvider" => typeof(XamlRootProviderSamplePage),
                 _ => null
             };

--- a/src/MZikmund.Toolkit.WinUI/Resources/ResourceAccessor.cs
+++ b/src/MZikmund.Toolkit.WinUI/Resources/ResourceAccessor.cs
@@ -1,0 +1,67 @@
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.UI.Xaml;
+
+namespace MZikmund.Toolkit.WinUI.Resources;
+
+/// <summary>
+/// Type-safe lookup of resources defined in <c>App.xaml</c> or any merged dictionary
+/// reachable through <see cref="Application.Current"/>.
+/// </summary>
+/// <remarks>
+/// Useful when XAML's <c>{StaticResource}</c> markup isn't available — for example, in
+/// behaviors, converters, or code-behind helpers that need a brush, style, or string
+/// from the application resource scope.
+/// </remarks>
+public static class ResourceAccessor
+{
+    /// <summary>
+    /// Looks up the resource with the given <paramref name="key"/> and casts it to <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="T">Expected resource type.</typeparam>
+    /// <param name="key">Resource key as declared in XAML (<c>x:Key</c>).</param>
+    /// <returns>The resource cast to <typeparamref name="T"/>.</returns>
+    /// <exception cref="InvalidOperationException">No <see cref="Application.Current"/> is available.</exception>
+    /// <exception cref="KeyNotFoundException">The key is not present in the application resources.</exception>
+    /// <exception cref="InvalidCastException">The resource exists but is not of type <typeparamref name="T"/>.</exception>
+    public static T GetResource<T>(string key)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+
+        var resources = Application.Current?.Resources
+            ?? throw new InvalidOperationException("Application.Current.Resources is not available. ResourceAccessor requires an initialized Application.");
+
+        if (!resources.TryGetValue(key, out var raw))
+        {
+            throw new KeyNotFoundException($"Resource '{key}' was not found in Application.Current.Resources.");
+        }
+
+        if (raw is T typed)
+        {
+            return typed;
+        }
+
+        throw new InvalidCastException($"Resource '{key}' is of type {raw?.GetType().FullName ?? "null"}, not {typeof(T).FullName}.");
+    }
+
+    /// <summary>
+    /// Tries to look up the resource with the given <paramref name="key"/> as <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="T">Expected resource type.</typeparam>
+    /// <param name="key">Resource key.</param>
+    /// <param name="value">The resource if the lookup succeeded; otherwise <c>default</c>.</param>
+    /// <returns><see langword="true"/> if a resource of type <typeparamref name="T"/> was found at <paramref name="key"/>; otherwise <see langword="false"/>.</returns>
+    public static bool TryGetResource<T>(string key, [MaybeNullWhen(false)] out T value)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+
+        var resources = Application.Current?.Resources;
+        if (resources is not null && resources.TryGetValue(key, out var raw) && raw is T typed)
+        {
+            value = typed;
+            return true;
+        }
+
+        value = default;
+        return false;
+    }
+}

--- a/tests/MZikmund.Toolkit.WinUI.Tests/ResourceAccessorTests.cs
+++ b/tests/MZikmund.Toolkit.WinUI.Tests/ResourceAccessorTests.cs
@@ -1,0 +1,48 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MZikmund.Toolkit.WinUI.Resources;
+
+namespace MZikmund.Toolkit.WinUI.Tests;
+
+[TestClass]
+public class ResourceAccessorTests
+{
+    // The headless test host has no initialized Application.Current, so these tests
+    // exercise the null-safety branches and argument validation. Happy-path lookups
+    // are exercised manually through the sample gallery page.
+
+    [TestMethod]
+    public void GetResource_NullKey_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => ResourceAccessor.GetResource<object>(null!));
+    }
+
+    [TestMethod]
+    public void TryGetResource_NullKey_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => ResourceAccessor.TryGetResource<object>(null!, out _));
+    }
+
+    [TestMethod]
+    public void GetResource_WithoutApplication_ThrowsInvalidOperation()
+    {
+        Assert.Throws<InvalidOperationException>(() => ResourceAccessor.GetResource<object>("AnyKey"));
+    }
+
+    [TestMethod]
+    public void TryGetResource_WithoutApplication_ReturnsFalse()
+    {
+        var result = ResourceAccessor.TryGetResource<object>("AnyKey", out var value);
+
+        Assert.IsFalse(result);
+        Assert.IsNull(value);
+    }
+
+    [TestMethod]
+    public void TryGetResource_WithoutApplication_ValueTypeOutDefault()
+    {
+        var result = ResourceAccessor.TryGetResource<int>("AnyKey", out var value);
+
+        Assert.IsFalse(result);
+        Assert.AreEqual(0, value);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `ResourceAccessor` static helper in `MZikmund.Toolkit.WinUI.Resources` with two methods:
  - `GetResource<T>(string key)` — throws `InvalidOperationException` if no `Application.Current`, `KeyNotFoundException` if the key is missing, `InvalidCastException` if the resource is the wrong type.
  - `TryGetResource<T>(string key, out T value)` — non-throwing variant for optional resources, returns `false` and `default` on any miss.
- Wires a gallery sample (`ResourceAccessorSamplePage`) into Shell + HomePage demonstrating Color/Brush/Style lookups against keys you type in.
- Adds 5 unit tests covering argument validation and the no-`Application.Current` branches. Happy-path lookups need a real XAML host and are exercised through the sample page.

Closes #33

> Stacked on top of #56 (the `MergeWith` PR). Rebase on `main` once #56 merges.

## Test plan

- [x] `dotnet build MZikmund.Toolkit.slnx -c Debug` succeeds.
- [x] Test exe reports 19/19 passed (14 prior + 5 new for `ResourceAccessor`).
- [ ] Manually exercise the `Resource Accessor` sample page on Windows: lookup `SystemAccentColor` as Color, `AccentFillColorDefaultBrush` as Brush, `BodyTextBlockStyle` as Style, plus a missing key and a wrong-type lookup to see the negative paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)