### PR TITLE
feat: Add IntToTimeComponentString and FullScreenIcon converters

### DIFF
--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/ConvertersSamplePage.xaml
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/ConvertersSamplePage.xaml
@@ -1,0 +1,96 @@
+<Page x:Class="MZikmund.Toolkit.Sample.ConvertersSamplePage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:local="using:MZikmund.Toolkit.Sample"
+      xmlns:converters="using:MZikmund.Toolkit.WinUI.Converters">
+
+  <Page.Resources>
+    <converters:IntToTimeComponentStringConverter x:Key="IntToTimeComponentStringConverter" />
+    <converters:FullScreenIconConverter x:Key="FullScreenIconConverter" />
+  </Page.Resources>
+
+  <ScrollViewer Padding="24">
+    <StackPanel Spacing="16" MaxWidth="800">
+      <TextBlock Text="Niche Converters"
+                 Style="{ThemeResource TitleTextBlockStyle}" />
+
+      <TextBlock Text="Two small but reusable XAML converters: IntToTimeComponentStringConverter (int → zero-padded two-digit string) and FullScreenIconConverter (bool → Symbol.FullScreen / Symbol.BackToWindow)."
+                 TextWrapping="Wrap"
+                 Style="{ThemeResource BodyTextBlockStyle}" />
+
+      <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+              BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+              BorderThickness="1"
+              CornerRadius="8"
+              Padding="16">
+        <StackPanel Spacing="12">
+          <TextBlock Text="IntToTimeComponentStringConverter"
+                     Style="{ThemeResource SubtitleTextBlockStyle}" />
+
+          <TextBlock Text="Drag the slider — the number is bound to a TextBlock through the converter."
+                     TextWrapping="Wrap"
+                     Style="{ThemeResource BodyTextBlockStyle}" />
+
+          <Slider x:Name="MinutesSlider"
+                  Minimum="0"
+                  Maximum="59"
+                  Value="5" />
+
+          <TextBlock FontFamily="Consolas"
+                     FontSize="40"
+                     HorizontalAlignment="Center">
+            <Run Text="{Binding ElementName=MinutesSlider, Path=Value, Converter={StaticResource IntToTimeComponentStringConverter}}" />
+            <Run Text=":00" />
+          </TextBlock>
+        </StackPanel>
+      </Border>
+
+      <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+              BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+              BorderThickness="1"
+              CornerRadius="8"
+              Padding="16">
+        <StackPanel Spacing="12">
+          <TextBlock Text="FullScreenIconConverter"
+                     Style="{ThemeResource SubtitleTextBlockStyle}" />
+
+          <TextBlock Text="Toggle the switch — the button icon flips between FullScreen and BackToWindow."
+                     TextWrapping="Wrap"
+                     Style="{ThemeResource BodyTextBlockStyle}" />
+
+          <ToggleSwitch x:Name="IsFullScreenToggle"
+                        Header="Is full screen"
+                        OnContent="On"
+                        OffContent="Off" />
+
+          <Button HorizontalAlignment="Left">
+            <SymbolIcon Symbol="{Binding ElementName=IsFullScreenToggle, Path=IsOn, Converter={StaticResource FullScreenIconConverter}}" />
+          </Button>
+        </StackPanel>
+      </Border>
+
+      <Border Background="{ThemeResource LayerFillColorDefaultBrush}"
+              BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+              BorderThickness="1"
+              CornerRadius="8"
+              Padding="16">
+        <StackPanel Spacing="8">
+          <TextBlock Text="Code Sample"
+                     Style="{ThemeResource SubtitleTextBlockStyle}" />
+
+          <TextBlock FontFamily="Consolas" TextWrapping="Wrap">
+            <Run>xmlns:converters="using:MZikmund.Toolkit.WinUI.Converters"</Run><LineBreak />
+            <LineBreak />
+            <Run>&lt;Page.Resources&gt;</Run><LineBreak />
+            <Run>  &lt;converters:IntToTimeComponentStringConverter x:Key="TimeComp" /&gt;</Run><LineBreak />
+            <Run>  &lt;converters:FullScreenIconConverter x:Key="FullScreenIcon" /&gt;</Run><LineBreak />
+            <Run>&lt;/Page.Resources&gt;</Run><LineBreak />
+            <LineBreak />
+            <Run>&lt;TextBlock Text="{Binding Minutes, Converter={StaticResource TimeComp}}" /&gt;</Run><LineBreak />
+            <Run>&lt;SymbolIcon Symbol="{Binding IsFullScreen, Converter={StaticResource FullScreenIcon}}" /&gt;</Run>
+          </TextBlock>
+        </StackPanel>
+      </Border>
+    </StackPanel>
+  </ScrollViewer>
+</Page>

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/ConvertersSamplePage.xaml.cs
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/ConvertersSamplePage.xaml.cs
@@ -1,0 +1,11 @@
+using Microsoft.UI.Xaml.Controls;
+
+namespace MZikmund.Toolkit.Sample;
+
+public sealed partial class ConvertersSamplePage : Page
+{
+    public ConvertersSamplePage()
+    {
+        this.InitializeComponent();
+    }
+}

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/HomePage.xaml
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/HomePage.xaml
@@ -40,6 +40,12 @@
           <Run Text="ObservableCollection Merge:" FontWeight="SemiBold" />
           <Run Text=" MergeWith extension that synchronizes an ObservableCollection with a source list using minimal Insert/RemoveAt/Move operations." />
         </TextBlock>
+
+        <TextBlock Style="{ThemeResource BodyTextBlockStyle}">
+          <Run Text="• " FontWeight="Bold" />
+          <Run Text="Niche Converters:" FontWeight="SemiBold" />
+          <Run Text=" IntToTimeComponentStringConverter and FullScreenIconConverter for clocks/timers and fullscreen toggle buttons." />
+        </TextBlock>
         
         <TextBlock Style="{ThemeResource BodyTextBlockStyle}">
           <Run Text="• " FontWeight="Bold" />

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml
@@ -18,6 +18,8 @@
       <NavigationViewItemHeader Content="Extensions" />
       <NavigationViewItem Content="Package Version" Tag="PackageVersion" Icon="Document" />
       <NavigationViewItem Content="ObservableCollection Merge" Tag="ObservableCollectionMerge" Icon="List" />
+      <NavigationViewItemHeader Content="Converters" />
+      <NavigationViewItem Content="Niche Converters" Tag="Converters" Icon="Switch" />
       <NavigationViewItemHeader Content="Infrastructure" />
       <NavigationViewItem Content="XamlRoot Provider" Tag="XamlRootProvider" Icon="Page" />
     </NavigationView.MenuItems>

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml.cs
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml.cs
@@ -30,6 +30,7 @@ public sealed partial class Shell : Page
                 "DialogCoordinator" => typeof(DialogCoordinatorSamplePage),
                 "PackageVersion" => typeof(PackageVersionSamplePage),
                 "ObservableCollectionMerge" => typeof(ObservableCollectionMergeSamplePage),
+                "Converters" => typeof(ConvertersSamplePage),
                 "XamlRootProvider" => typeof(XamlRootProviderSamplePage),
                 _ => null
             };

--- a/src/MZikmund.Toolkit.WinUI/Converters/FullScreenIconConverter.cs
+++ b/src/MZikmund.Toolkit.WinUI/Converters/FullScreenIconConverter.cs
@@ -1,0 +1,20 @@
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Data;
+
+namespace MZikmund.Toolkit.WinUI.Converters;
+
+/// <summary>
+/// Maps a <see cref="bool"/> "is full screen" state to a <see cref="Symbol"/>:
+/// <see cref="Symbol.BackToWindow"/> when full-screen, <see cref="Symbol.FullScreen"/> otherwise.
+/// Useful for the icon on a fullscreen toggle button.
+/// </summary>
+public sealed class FullScreenIconConverter : IValueConverter
+{
+    /// <inheritdoc />
+    public object Convert(object value, Type targetType, object parameter, string language) =>
+        value is true ? Symbol.BackToWindow : Symbol.FullScreen;
+
+    /// <inheritdoc />
+    public object ConvertBack(object value, Type targetType, object parameter, string language) =>
+        value is Symbol.BackToWindow;
+}

--- a/src/MZikmund.Toolkit.WinUI/Converters/IntToTimeComponentStringConverter.cs
+++ b/src/MZikmund.Toolkit.WinUI/Converters/IntToTimeComponentStringConverter.cs
@@ -1,0 +1,30 @@
+using Microsoft.UI.Xaml.Data;
+
+namespace MZikmund.Toolkit.WinUI.Converters;
+
+/// <summary>
+/// Formats an integer as a zero-padded two-digit string ("05", "12", "59").
+/// Useful for clock, countdown, and timer displays where each component needs
+/// fixed width.
+/// </summary>
+public sealed class IntToTimeComponentStringConverter : IValueConverter
+{
+    /// <inheritdoc />
+    public object Convert(object value, Type targetType, object parameter, string language)
+    {
+        var number = value switch
+        {
+            int i => i,
+            long l => (int)l,
+            short s => s,
+            byte b => b,
+            _ => System.Convert.ToInt32(value, System.Globalization.CultureInfo.InvariantCulture),
+        };
+
+        return number.ToString("00", System.Globalization.CultureInfo.InvariantCulture);
+    }
+
+    /// <inheritdoc />
+    public object ConvertBack(object value, Type targetType, object parameter, string language) =>
+        throw new NotSupportedException($"{nameof(IntToTimeComponentStringConverter)} only supports one-way binding.");
+}

--- a/tests/MZikmund.Toolkit.WinUI.Tests/FullScreenIconConverterTests.cs
+++ b/tests/MZikmund.Toolkit.WinUI.Tests/FullScreenIconConverterTests.cs
@@ -1,0 +1,48 @@
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MZikmund.Toolkit.WinUI.Converters;
+
+namespace MZikmund.Toolkit.WinUI.Tests;
+
+[TestClass]
+public class FullScreenIconConverterTests
+{
+    private static readonly FullScreenIconConverter Converter = new();
+
+    [TestMethod]
+    public void Convert_True_ReturnsBackToWindow()
+    {
+        Assert.AreEqual(Symbol.BackToWindow, Converter.Convert(true, typeof(Symbol), null!, null!));
+    }
+
+    [TestMethod]
+    public void Convert_False_ReturnsFullScreen()
+    {
+        Assert.AreEqual(Symbol.FullScreen, Converter.Convert(false, typeof(Symbol), null!, null!));
+    }
+
+    [TestMethod]
+    public void Convert_Null_ReturnsFullScreen()
+    {
+        Assert.AreEqual(Symbol.FullScreen, Converter.Convert(null!, typeof(Symbol), null!, null!));
+    }
+
+    [TestMethod]
+    public void Convert_NonBool_ReturnsFullScreen()
+    {
+        // Non-bool inputs are treated as "not full screen".
+        Assert.AreEqual(Symbol.FullScreen, Converter.Convert("yes", typeof(Symbol), null!, null!));
+    }
+
+    [TestMethod]
+    public void ConvertBack_BackToWindow_ReturnsTrue()
+    {
+        Assert.AreEqual(true, Converter.ConvertBack(Symbol.BackToWindow, typeof(bool), null!, null!));
+    }
+
+    [TestMethod]
+    public void ConvertBack_FullScreen_ReturnsFalse()
+    {
+        Assert.AreEqual(false, Converter.ConvertBack(Symbol.FullScreen, typeof(bool), null!, null!));
+    }
+}

--- a/tests/MZikmund.Toolkit.WinUI.Tests/IntToTimeComponentStringConverterTests.cs
+++ b/tests/MZikmund.Toolkit.WinUI.Tests/IntToTimeComponentStringConverterTests.cs
@@ -1,0 +1,61 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MZikmund.Toolkit.WinUI.Converters;
+
+namespace MZikmund.Toolkit.WinUI.Tests;
+
+[TestClass]
+public class IntToTimeComponentStringConverterTests
+{
+    private static readonly IntToTimeComponentStringConverter Converter = new();
+
+    [TestMethod]
+    public void Convert_SingleDigit_ZeroPaddedToTwo()
+    {
+        Assert.AreEqual("05", Converter.Convert(5, typeof(string), null!, null!));
+    }
+
+    [TestMethod]
+    public void Convert_TwoDigits_NotPadded()
+    {
+        Assert.AreEqual("42", Converter.Convert(42, typeof(string), null!, null!));
+    }
+
+    [TestMethod]
+    public void Convert_Zero_ReturnsDoubleZero()
+    {
+        Assert.AreEqual("00", Converter.Convert(0, typeof(string), null!, null!));
+    }
+
+    [TestMethod]
+    public void Convert_ThreeDigits_NotTruncated()
+    {
+        // Format "00" widens but does not truncate.
+        Assert.AreEqual("123", Converter.Convert(123, typeof(string), null!, null!));
+    }
+
+    [TestMethod]
+    public void Convert_Negative_KeepsSign()
+    {
+        // The "00" format preserves negative sign and pads digits.
+        Assert.AreEqual("-05", Converter.Convert(-5, typeof(string), null!, null!));
+    }
+
+    [TestMethod]
+    public void Convert_Long_Coerced()
+    {
+        Assert.AreEqual("07", Converter.Convert(7L, typeof(string), null!, null!));
+    }
+
+    [TestMethod]
+    public void Convert_Double_CoercedThroughIConvertible()
+    {
+        Assert.AreEqual("09", Converter.Convert(9.4, typeof(string), null!, null!));
+    }
+
+    [TestMethod]
+    public void ConvertBack_NotSupported()
+    {
+        Assert.Throws<NotSupportedException>(() =>
+            Converter.ConvertBack("05", typeof(int), null!, null!));
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `IntToTimeComponentStringConverter` in `MZikmund.Toolkit.WinUI.Converters` — formats an integer as a zero-padded two-digit string ("05", "12", "59"). Coerces common numeric inputs (`int`, `long`, `short`, `byte`, `double`) and uses invariant culture.
- Adds `FullScreenIconConverter` in the same namespace — `bool → Symbol.FullScreen / Symbol.BackToWindow` for a fullscreen toggle button. Round-trips via `ConvertBack`.
- Wires a gallery sample (`ConvertersSamplePage`) into Shell + HomePage with a Slider bound through `IntToTimeComponentStringConverter` and a ToggleSwitch driving a `SymbolIcon` through `FullScreenIconConverter`.
- Adds 14 unit tests across both converters covering padding, coercion, sign handling, round-trip, and the unsupported `ConvertBack` path on the time-component converter.

Closes #30

> Stacked on top of #56 (the `MergeWith` PR). Rebase on `main` once #56 merges.

## Test plan

- [x] `dotnet build MZikmund.Toolkit.slnx -c Debug` succeeds.
- [x] Test exe reports 28/28 passed (14 prior + 14 new).
- [ ] Manually exercise the `Niche Converters` sample page on Windows: drag the slider 0→59 and verify the textblock zero-pads single digits; toggle the switch and verify the button icon flips between FullScreen and BackToWindow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)