### PR TITLE
feat: Add ContainsKey/Remove/Clear to IPreferences

### DIFF
--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/PreferencesSamplePage.xaml
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/PreferencesSamplePage.xaml
@@ -77,6 +77,37 @@
         </StackPanel>
       </Border>
       
+      <!-- Maintenance Sample -->
+      <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+              BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+              BorderThickness="1"
+              CornerRadius="8"
+              Padding="16">
+        <StackPanel Spacing="12">
+          <TextBlock Text="Maintenance — ContainsKey / Remove / Clear"
+                     Style="{ThemeResource SubtitleTextBlockStyle}" />
+
+          <TextBlock Text="Inspect and bulk-modify stored preferences."
+                     TextWrapping="Wrap"
+                     Style="{ThemeResource BodyTextBlockStyle}" />
+
+          <TextBox x:Name="MaintenanceKeyInput"
+                   Header="Key to check or remove"
+                   PlaceholderText="SampleString"
+                   Text="SampleString" />
+
+          <StackPanel Orientation="Horizontal" Spacing="8">
+            <Button Content="Contains key?" Click="ContainsKey_Click" />
+            <Button Content="Remove key" Click="RemoveKey_Click" />
+            <Button Content="Clear all" Click="ClearAll_Click" />
+          </StackPanel>
+
+          <TextBlock x:Name="MaintenanceResult"
+                     Text="No action taken yet."
+                     Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}" />
+        </StackPanel>
+      </Border>
+
       <!-- Code Sample -->
       <Border Background="{ThemeResource LayerFillColorDefaultBrush}"
               BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/PreferencesSamplePage.xaml.cs
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/PreferencesSamplePage.xaml.cs
@@ -81,6 +81,32 @@ public sealed partial class PreferencesSamplePage : Page
         ComplexValueResult.Text = "Person cleared";
     }
 
+    private void ContainsKey_Click(object sender, RoutedEventArgs e)
+    {
+        var key = MaintenanceKeyInput.Text;
+        MaintenanceResult.Text = _preferences.ContainsKey(key)
+            ? $"Key '{key}' is present."
+            : $"Key '{key}' is not stored.";
+    }
+
+    private void RemoveKey_Click(object sender, RoutedEventArgs e)
+    {
+        var key = MaintenanceKeyInput.Text;
+        _preferences.Remove(key);
+        MaintenanceResult.Text = $"Removed '{key}' (if it existed).";
+    }
+
+    private void ClearAll_Click(object sender, RoutedEventArgs e)
+    {
+        _preferences.Clear();
+        SimpleValueInput.Text = string.Empty;
+        SimpleValueResult.Text = "No value stored";
+        PersonNameInput.Text = string.Empty;
+        PersonAgeInput.Text = string.Empty;
+        ComplexValueResult.Text = "No person stored";
+        MaintenanceResult.Text = "All preferences cleared.";
+    }
+
     private class Person
     {
         public string Name { get; set; } = string.Empty;

--- a/src/MZikmund.Toolkit.WinUI/Services/IPreferences.cs
+++ b/src/MZikmund.Toolkit.WinUI/Services/IPreferences.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
 
 namespace MZikmund.Toolkit.WinUI.Services;
 
@@ -14,7 +14,6 @@ public interface IPreferences
     /// <param name="key">Key.</param>
     /// <param name="defaultValue">Default value.</param>
     /// <returns>Value from settings or default value.</returns>
-    /// </summary>
     T Get<T>(string key, T defaultValue);
 
     /// <summary>
@@ -41,7 +40,6 @@ public interface IPreferences
     /// <param name="key">Key.</param>
     /// <param name="defaultValue">Default value.</param>
     /// <returns>Value from settings or default value.</returns>
-    /// </summary>
     T GetComplex<T>(string key, T defaultValue);
 
     /// <summary>
@@ -62,4 +60,22 @@ public interface IPreferences
     /// <param name="key">Key.</param>
     /// <param name="value">Value.</param>
     void SetComplex<T>(string key, T? value);
+
+    /// <summary>
+    /// Determines whether a setting with the given key exists.
+    /// </summary>
+    /// <param name="key">Key.</param>
+    /// <returns><see langword="true"/> if a value is stored under <paramref name="key"/>.</returns>
+    bool ContainsKey(string key);
+
+    /// <summary>
+    /// Removes the setting stored under the given key. Does nothing if no such setting exists.
+    /// </summary>
+    /// <param name="key">Key.</param>
+    void Remove(string key);
+
+    /// <summary>
+    /// Removes all stored preferences.
+    /// </summary>
+    void Clear();
 }

--- a/src/MZikmund.Toolkit.WinUI/Services/Preferences.cs
+++ b/src/MZikmund.Toolkit.WinUI/Services/Preferences.cs
@@ -167,4 +167,22 @@ public class Preferences : IPreferences
     /// </summary>
     public T GetComplex<T>(string key, T defaultValue) => TryGetComplex<T>(key, out var value) ?
         value : defaultValue;
+
+    /// <inheritdoc />
+    public bool ContainsKey(string key) =>
+        _preferenceCache.ContainsKey(key) || _container.Values.ContainsKey(key);
+
+    /// <inheritdoc />
+    public void Remove(string key)
+    {
+        _preferenceCache.Remove(key);
+        _container.Values.Remove(key);
+    }
+
+    /// <inheritdoc />
+    public void Clear()
+    {
+        _preferenceCache.Clear();
+        _container.Values.Clear();
+    }
 }


### PR DESCRIPTION
## Summary

- Extends `IPreferences` with three methods to reach parity with the template's local wrapper:
  - `bool ContainsKey(string key)` — checks both the cache and the underlying `LocalSettings`.
  - `void Remove(string key)` — removes a single setting (no-op if absent).
  - `void Clear()` — wipes the cache and `LocalSettings.Values`.
- Implements all three on `Preferences`.
- Updates `PreferencesSamplePage` with a new "Maintenance" card driving each method end-to-end with a key textbox and three buttons.

Once this lands, the template can delete its duplicate `IPreferences` / `Preferences` and reference the toolkit version directly.

Closes #55

> Stacked on top of #56 (the `MergeWith` PR). Rebase on `main` once #56 merges.

## Test plan

- [x] `dotnet build MZikmund.Toolkit.slnx -c Debug` succeeds.
- [x] Test exe still reports 14/14 passed (no new headless tests — `Preferences` depends on `ApplicationData.Current`, exercised through the sample).
- [ ] Manually exercise the Preferences sample page on Windows: save a value → "Contains key?" yes → "Remove key" → "Contains key?" no → save several → "Clear all" → confirm everything resets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)