### PR TITLE
feat: Add PaginatedResponse<T> generic DTO

### DIFF
--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/HomePage.xaml
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/HomePage.xaml
@@ -40,6 +40,12 @@
           <Run Text="ObservableCollection Merge:" FontWeight="SemiBold" />
           <Run Text=" MergeWith extension that synchronizes an ObservableCollection with a source list using minimal Insert/RemoveAt/Move operations." />
         </TextBlock>
+
+        <TextBlock Style="{ThemeResource BodyTextBlockStyle}">
+          <Run Text="• " FontWeight="Bold" />
+          <Run Text="Paginated Response:" FontWeight="SemiBold" />
+          <Run Text=" PaginatedResponse&lt;T&gt; generic DTO with computed TotalPages / HasPreviousPage / HasNextPage." />
+        </TextBlock>
         
         <TextBlock Style="{ThemeResource BodyTextBlockStyle}">
           <Run Text="• " FontWeight="Bold" />

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/PaginatedResponseSamplePage.xaml
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/PaginatedResponseSamplePage.xaml
@@ -1,0 +1,72 @@
+<Page x:Class="MZikmund.Toolkit.Sample.PaginatedResponseSamplePage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:local="using:MZikmund.Toolkit.Sample">
+
+  <ScrollViewer Padding="24">
+    <StackPanel Spacing="16" MaxWidth="800">
+      <TextBlock Text="PaginatedResponse&lt;T&gt;"
+                 Style="{ThemeResource TitleTextBlockStyle}" />
+
+      <TextBlock Text="A small generic DTO for paginated API responses. Items + Page + PageSize + TotalCount, with computed TotalPages, HasPreviousPage, HasNextPage."
+                 TextWrapping="Wrap"
+                 Style="{ThemeResource BodyTextBlockStyle}" />
+
+      <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+              BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+              BorderThickness="1"
+              CornerRadius="8"
+              Padding="16">
+        <StackPanel Spacing="12">
+          <TextBlock Text="Simulated paginated query"
+                     Style="{ThemeResource SubtitleTextBlockStyle}" />
+
+          <TextBlock x:Name="StatusText"
+                     Style="{ThemeResource BodyTextBlockStyle}" />
+
+          <Border BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                  BorderThickness="1"
+                  CornerRadius="4"
+                  Height="220">
+            <ListView x:Name="ItemsList" SelectionMode="None" />
+          </Border>
+
+          <StackPanel Orientation="Horizontal" Spacing="8">
+            <Button x:Name="PrevButton" Content="Previous" Click="Prev_Click" />
+            <Button x:Name="NextButton" Content="Next" Click="Next_Click" />
+            <ComboBox x:Name="PageSizePicker" Header="Page size" SelectionChanged="PageSize_Changed">
+              <x:Int32>5</x:Int32>
+              <x:Int32>10</x:Int32>
+              <x:Int32>20</x:Int32>
+            </ComboBox>
+          </StackPanel>
+        </StackPanel>
+      </Border>
+
+      <Border Background="{ThemeResource LayerFillColorDefaultBrush}"
+              BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+              BorderThickness="1"
+              CornerRadius="8"
+              Padding="16">
+        <StackPanel Spacing="8">
+          <TextBlock Text="Code Sample"
+                     Style="{ThemeResource SubtitleTextBlockStyle}" />
+
+          <TextBlock FontFamily="Consolas" TextWrapping="Wrap">
+            <Run>using MZikmund.Toolkit.WinUI.Models;</Run><LineBreak />
+            <LineBreak />
+            <Run>var response = new PaginatedResponse&lt;Order&gt;(</Run><LineBreak />
+            <Run>    Items: orders,</Run><LineBreak />
+            <Run>    Page: 2,</Run><LineBreak />
+            <Run>    PageSize: 20,</Run><LineBreak />
+            <Run>    TotalCount: 137);</Run><LineBreak />
+            <LineBreak />
+            <Run>// response.TotalPages == 7</Run><LineBreak />
+            <Run>// response.HasPreviousPage == true</Run><LineBreak />
+            <Run>// response.HasNextPage == true</Run>
+          </TextBlock>
+        </StackPanel>
+      </Border>
+    </StackPanel>
+  </ScrollViewer>
+</Page>

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/PaginatedResponseSamplePage.xaml.cs
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/PaginatedResponseSamplePage.xaml.cs
@@ -1,0 +1,65 @@
+using Microsoft.UI.Xaml.Controls;
+using MZikmund.Toolkit.WinUI.Models;
+
+namespace MZikmund.Toolkit.Sample;
+
+public sealed partial class PaginatedResponseSamplePage : Page
+{
+    private static readonly string[] AllItems =
+        Enumerable.Range(1, 137).Select(i => $"Item #{i:000}").ToArray();
+
+    private int _currentPage = 1;
+    private int _pageSize = 10;
+
+    public PaginatedResponseSamplePage()
+    {
+        this.InitializeComponent();
+        PageSizePicker.SelectedIndex = 1;
+        Refresh();
+    }
+
+    private void Prev_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
+    {
+        _currentPage--;
+        Refresh();
+    }
+
+    private void Next_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
+    {
+        _currentPage++;
+        Refresh();
+    }
+
+    private void PageSize_Changed(object sender, SelectionChangedEventArgs e)
+    {
+        if (PageSizePicker.SelectedItem is int newSize && newSize > 0)
+        {
+            _pageSize = newSize;
+            _currentPage = 1;
+            Refresh();
+        }
+    }
+
+    private void Refresh()
+    {
+        var response = QueryPage(_currentPage, _pageSize);
+
+        ItemsList.ItemsSource = response.Items;
+        StatusText.Text =
+            $"Page {response.Page} of {response.TotalPages} • {response.Items.Length} of {response.TotalCount} items";
+        PrevButton.IsEnabled = response.HasPreviousPage;
+        NextButton.IsEnabled = response.HasNextPage;
+    }
+
+    private static PaginatedResponse<string> QueryPage(int page, int pageSize)
+    {
+        if (pageSize <= 0)
+        {
+            return PaginatedResponse<string>.Empty();
+        }
+
+        var skip = (page - 1) * pageSize;
+        var slice = AllItems.Skip(skip).Take(pageSize).ToArray();
+        return new PaginatedResponse<string>(slice, page, pageSize, AllItems.Length);
+    }
+}

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml
@@ -18,6 +18,8 @@
       <NavigationViewItemHeader Content="Extensions" />
       <NavigationViewItem Content="Package Version" Tag="PackageVersion" Icon="Document" />
       <NavigationViewItem Content="ObservableCollection Merge" Tag="ObservableCollectionMerge" Icon="List" />
+      <NavigationViewItemHeader Content="Models" />
+      <NavigationViewItem Content="Paginated Response" Tag="PaginatedResponse" Icon="AllApps" />
       <NavigationViewItemHeader Content="Infrastructure" />
       <NavigationViewItem Content="XamlRoot Provider" Tag="XamlRootProvider" Icon="Page" />
     </NavigationView.MenuItems>

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml.cs
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml.cs
@@ -30,6 +30,7 @@ public sealed partial class Shell : Page
                 "DialogCoordinator" => typeof(DialogCoordinatorSamplePage),
                 "PackageVersion" => typeof(PackageVersionSamplePage),
                 "ObservableCollectionMerge" => typeof(ObservableCollectionMergeSamplePage),
+                "PaginatedResponse" => typeof(PaginatedResponseSamplePage),
                 "XamlRootProvider" => typeof(XamlRootProviderSamplePage),
                 _ => null
             };

--- a/src/MZikmund.Toolkit.WinUI/Models/PaginatedResponse.cs
+++ b/src/MZikmund.Toolkit.WinUI/Models/PaginatedResponse.cs
@@ -1,0 +1,40 @@
+namespace MZikmund.Toolkit.WinUI.Models;
+
+/// <summary>
+/// Generic DTO for a single page of a paginated API response.
+/// </summary>
+/// <typeparam name="T">Element type.</typeparam>
+/// <param name="Items">Items in this page.</param>
+/// <param name="Page">1-based page number this response represents.</param>
+/// <param name="PageSize">Maximum items per page.</param>
+/// <param name="TotalCount">Total number of items across all pages.</param>
+public sealed record PaginatedResponse<T>(
+    T[] Items,
+    int Page,
+    int PageSize,
+    int TotalCount)
+{
+    /// <summary>
+    /// Total number of pages. Zero when <see cref="TotalCount"/> is zero or <see cref="PageSize"/> is non-positive.
+    /// </summary>
+    public int TotalPages => PageSize > 0
+        ? (int)Math.Ceiling(TotalCount / (double)PageSize)
+        : 0;
+
+    /// <summary>
+    /// <see langword="true"/> when a page exists before this one.
+    /// </summary>
+    public bool HasPreviousPage => Page > 1;
+
+    /// <summary>
+    /// <see langword="true"/> when a page exists after this one.
+    /// </summary>
+    public bool HasNextPage => Page < TotalPages;
+
+    /// <summary>
+    /// Convenience: an empty response (page 1 of 0 items).
+    /// </summary>
+    /// <param name="pageSize">Page size to record on the empty response.</param>
+    public static PaginatedResponse<T> Empty(int pageSize = 0) =>
+        new(Array.Empty<T>(), Page: 1, PageSize: pageSize, TotalCount: 0);
+}

--- a/tests/MZikmund.Toolkit.WinUI.Tests/PaginatedResponseTests.cs
+++ b/tests/MZikmund.Toolkit.WinUI.Tests/PaginatedResponseTests.cs
@@ -1,0 +1,94 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MZikmund.Toolkit.WinUI.Models;
+
+namespace MZikmund.Toolkit.WinUI.Tests;
+
+[TestClass]
+public class PaginatedResponseTests
+{
+    [TestMethod]
+    public void TotalPages_ExactDivisor()
+    {
+        var response = new PaginatedResponse<int>([1, 2], Page: 1, PageSize: 10, TotalCount: 100);
+
+        Assert.AreEqual(10, response.TotalPages);
+    }
+
+    [TestMethod]
+    public void TotalPages_RoundsUpForRemainder()
+    {
+        var response = new PaginatedResponse<int>([], Page: 1, PageSize: 20, TotalCount: 137);
+
+        Assert.AreEqual(7, response.TotalPages);
+    }
+
+    [TestMethod]
+    public void TotalPages_ZeroTotalCount_IsZero()
+    {
+        var response = new PaginatedResponse<int>([], Page: 1, PageSize: 10, TotalCount: 0);
+
+        Assert.AreEqual(0, response.TotalPages);
+    }
+
+    [TestMethod]
+    public void TotalPages_ZeroPageSize_IsZero()
+    {
+        var response = new PaginatedResponse<int>([], Page: 1, PageSize: 0, TotalCount: 10);
+
+        Assert.AreEqual(0, response.TotalPages);
+    }
+
+    [TestMethod]
+    public void HasPreviousPage_OnFirstPage_IsFalse()
+    {
+        var response = new PaginatedResponse<int>([], Page: 1, PageSize: 10, TotalCount: 100);
+
+        Assert.IsFalse(response.HasPreviousPage);
+    }
+
+    [TestMethod]
+    public void HasPreviousPage_OnLaterPage_IsTrue()
+    {
+        var response = new PaginatedResponse<int>([], Page: 4, PageSize: 10, TotalCount: 100);
+
+        Assert.IsTrue(response.HasPreviousPage);
+    }
+
+    [TestMethod]
+    public void HasNextPage_OnLastPage_IsFalse()
+    {
+        var response = new PaginatedResponse<int>([], Page: 10, PageSize: 10, TotalCount: 100);
+
+        Assert.IsFalse(response.HasNextPage);
+    }
+
+    [TestMethod]
+    public void HasNextPage_OnEarlierPage_IsTrue()
+    {
+        var response = new PaginatedResponse<int>([], Page: 5, PageSize: 10, TotalCount: 100);
+
+        Assert.IsTrue(response.HasNextPage);
+    }
+
+    [TestMethod]
+    public void Empty_HasNoItems()
+    {
+        var empty = PaginatedResponse<string>.Empty();
+
+        Assert.AreEqual(0, empty.Items.Length);
+        Assert.AreEqual(0, empty.TotalCount);
+        Assert.AreEqual(0, empty.TotalPages);
+        Assert.IsFalse(empty.HasPreviousPage);
+        Assert.IsFalse(empty.HasNextPage);
+    }
+
+    [TestMethod]
+    public void Records_SameValues_AreEqual()
+    {
+        var a = new PaginatedResponse<int>([1, 2], Page: 1, PageSize: 10, TotalCount: 2);
+        var b = a with { };
+
+        // Reference equality of arrays is preserved by `with`, so these records compare equal.
+        Assert.AreEqual(a, b);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `PaginatedResponse<T>` record DTO in `MZikmund.Toolkit.WinUI.Models` with `Items`, `Page`, `PageSize`, `TotalCount`, plus computed `TotalPages`, `HasPreviousPage`, `HasNextPage`. Page numbering is **1-based**; `TotalPages` is 0 when `TotalCount` is 0 or `PageSize` is non-positive.
- Adds `PaginatedResponse<T>.Empty(pageSize = 0)` for the no-results case.
- Wires a gallery sample (`PaginatedResponseSamplePage`) into Shell + HomePage that walks through a 137-item simulated query with selectable page size and Prev/Next buttons that disable at the boundaries.
- Adds 10 unit tests covering exact divisor / remainder pagination, zero edge cases, prev/next boundary behavior, the `Empty` helper, and record equality.

> Future: when a `MZikmund.Toolkit.Shared` (UI-free) package is introduced, this DTO is a good candidate to move there. For now it lives in the WinUI package since that's the only published assembly and the type itself has no UI dependencies.

Closes #41

> Stacked on top of #56 (the `MergeWith` PR). Rebase on `main` once #56 merges.

## Test plan

- [x] `dotnet build MZikmund.Toolkit.slnx -c Debug` succeeds.
- [x] Test exe reports 24/24 passed (14 prior + 10 new).
- [ ] Manually exercise the `Paginated Response` sample on Windows: switch page size 5/10/20, verify Prev disables on page 1 and Next disables on the last page; status text shows accurate page-of-pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)