### PR TITLE
feat: Add NullToVisibility and EnumLocalization converters

### DIFF
--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/HomePage.xaml
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/HomePage.xaml
@@ -46,6 +46,12 @@
           <Run Text="Localizer:" FontWeight="SemiBold" />
           <Run Text=" ILocalizer abstraction with static Localizer.Current accessor and a {Localize} XAML markup extension." />
         </TextBlock>
+
+        <TextBlock Style="{ThemeResource BodyTextBlockStyle}">
+          <Run Text="• " FontWeight="Bold" />
+          <Run Text="Null + Enum Converters:" FontWeight="SemiBold" />
+          <Run Text=" NullToVisibilityConverter (with Invert) and EnumLocalizationConverter using the EnumType_Value convention." />
+        </TextBlock>
         
         <TextBlock Style="{ThemeResource BodyTextBlockStyle}">
           <Run Text="• " FontWeight="Bold" />

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/NullEnumConvertersSamplePage.xaml
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/NullEnumConvertersSamplePage.xaml
@@ -1,0 +1,98 @@
+<Page x:Class="MZikmund.Toolkit.Sample.NullEnumConvertersSamplePage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:local="using:MZikmund.Toolkit.Sample"
+      xmlns:converters="using:MZikmund.Toolkit.WinUI.Converters">
+
+  <Page.Resources>
+    <converters:NullToVisibilityConverter x:Key="NullToVisibility" />
+    <converters:NullToVisibilityConverter x:Key="NullToVisibilityInverted" Invert="True" />
+    <converters:EnumLocalizationConverter x:Key="EnumLocalization" />
+  </Page.Resources>
+
+  <ScrollViewer Padding="24">
+    <StackPanel Spacing="16" MaxWidth="800">
+      <TextBlock Text="Null + Enum Localization Converters"
+                 Style="{ThemeResource TitleTextBlockStyle}" />
+
+      <TextBlock Text="Two more XAML converters: NullToVisibilityConverter (toggle visibility based on null/non-null with optional Invert) and EnumLocalizationConverter (resolve enum values through ILocalizer)."
+                 TextWrapping="Wrap"
+                 Style="{ThemeResource BodyTextBlockStyle}" />
+
+      <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+              BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+              BorderThickness="1"
+              CornerRadius="8"
+              Padding="16">
+        <StackPanel Spacing="12">
+          <TextBlock Text="NullToVisibilityConverter"
+                     Style="{ThemeResource SubtitleTextBlockStyle}" />
+
+          <TextBlock Text="Toggle the textbox content. The first message shows when content is non-empty; the second (Invert=True) shows when content is empty."
+                     TextWrapping="Wrap"
+                     Style="{ThemeResource BodyTextBlockStyle}" />
+
+          <TextBox x:Name="ContentInput" Header="Bound value" PlaceholderText="Type or clear" />
+
+          <TextBlock Text="✅ Has content!"
+                     Foreground="{ThemeResource SystemFillColorSuccessBrush}"
+                     Visibility="{Binding ElementName=ContentInput, Path=Text, Converter={StaticResource NullToVisibility}}" />
+
+          <TextBlock Text="⚠ Empty — please type something."
+                     Foreground="{ThemeResource SystemFillColorCautionBrush}"
+                     Visibility="{Binding ElementName=ContentInput, Path=Text, Converter={StaticResource NullToVisibilityInverted}}" />
+        </StackPanel>
+      </Border>
+
+      <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+              BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+              BorderThickness="1"
+              CornerRadius="8"
+              Padding="16">
+        <StackPanel Spacing="12">
+          <TextBlock Text="EnumLocalizationConverter"
+                     Style="{ThemeResource SubtitleTextBlockStyle}" />
+
+          <TextBlock Text="The OrderStatus enum's three values are looked up through Localizer.Current using the convention OrderStatus_{ValueName}. Click a button to update the bound value, then try the language buttons to switch the active localizer."
+                     TextWrapping="Wrap"
+                     Style="{ThemeResource BodyTextBlockStyle}" />
+
+          <StackPanel Orientation="Horizontal" Spacing="8">
+            <Button Content="Pending" Click="SetPending_Click" />
+            <Button Content="Shipped" Click="SetShipped_Click" />
+            <Button Content="Delivered" Click="SetDelivered_Click" />
+          </StackPanel>
+
+          <TextBlock x:Name="LocalizedStatus"
+                     Style="{ThemeResource BodyStrongTextBlockStyle}" />
+
+          <StackPanel Orientation="Horizontal" Spacing="8">
+            <Button Content="English" Click="UseEnglish_Click" Style="{ThemeResource AccentButtonStyle}" />
+            <Button Content="Czech" Click="UseCzech_Click" />
+          </StackPanel>
+        </StackPanel>
+      </Border>
+
+      <Border Background="{ThemeResource LayerFillColorDefaultBrush}"
+              BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+              BorderThickness="1"
+              CornerRadius="8"
+              Padding="16">
+        <StackPanel Spacing="8">
+          <TextBlock Text="Code Sample"
+                     Style="{ThemeResource SubtitleTextBlockStyle}" />
+
+          <TextBlock FontFamily="Consolas" TextWrapping="Wrap">
+            <Run>xmlns:converters="using:MZikmund.Toolkit.WinUI.Converters"</Run><LineBreak />
+            <LineBreak />
+            <Run>&lt;converters:NullToVisibilityConverter x:Key="NullToVis" /&gt;</Run><LineBreak />
+            <Run>&lt;converters:EnumLocalizationConverter x:Key="EnumLoc" /&gt;</Run><LineBreak />
+            <LineBreak />
+            <Run>&lt;TextBlock Visibility="{Binding User, Converter={StaticResource NullToVis}}" /&gt;</Run><LineBreak />
+            <Run>&lt;TextBlock Text="{Binding Status, Converter={StaticResource EnumLoc}}" /&gt;</Run>
+          </TextBlock>
+        </StackPanel>
+      </Border>
+    </StackPanel>
+  </ScrollViewer>
+</Page>

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/NullEnumConvertersSamplePage.xaml.cs
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/NullEnumConvertersSamplePage.xaml.cs
@@ -1,0 +1,76 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using MZikmund.Toolkit.WinUI.Converters;
+using MZikmund.Toolkit.WinUI.Localization;
+
+namespace MZikmund.Toolkit.Sample;
+
+public sealed partial class NullEnumConvertersSamplePage : Page
+{
+    private static readonly DictionaryLocalizer English = new(new()
+    {
+        ["OrderStatus_Pending"] = "Pending",
+        ["OrderStatus_Shipped"] = "Shipped",
+        ["OrderStatus_Delivered"] = "Delivered",
+    });
+
+    private static readonly DictionaryLocalizer Czech = new(new()
+    {
+        ["OrderStatus_Pending"] = "Čeká na zpracování",
+        ["OrderStatus_Shipped"] = "Odesláno",
+        ["OrderStatus_Delivered"] = "Doručeno",
+    });
+
+    private readonly EnumLocalizationConverter _converter = new();
+    private OrderStatus _status = OrderStatus.Pending;
+
+    public NullEnumConvertersSamplePage()
+    {
+        Localizer.Current = English;
+        this.InitializeComponent();
+        Refresh();
+    }
+
+    private void SetPending_Click(object sender, RoutedEventArgs e) => Set(OrderStatus.Pending);
+
+    private void SetShipped_Click(object sender, RoutedEventArgs e) => Set(OrderStatus.Shipped);
+
+    private void SetDelivered_Click(object sender, RoutedEventArgs e) => Set(OrderStatus.Delivered);
+
+    private void UseEnglish_Click(object sender, RoutedEventArgs e)
+    {
+        Localizer.Current = English;
+        Refresh();
+    }
+
+    private void UseCzech_Click(object sender, RoutedEventArgs e)
+    {
+        Localizer.Current = Czech;
+        Refresh();
+    }
+
+    private void Set(OrderStatus status)
+    {
+        _status = status;
+        Refresh();
+    }
+
+    private void Refresh()
+    {
+        var localized = (string)_converter.Convert(_status, typeof(string), null!, null!);
+        LocalizedStatus.Text = $"{_status} → \"{localized}\"";
+    }
+
+    private enum OrderStatus
+    {
+        Pending,
+        Shipped,
+        Delivered,
+    }
+
+    private sealed class DictionaryLocalizer(Dictionary<string, string> entries) : ILocalizer
+    {
+        public string GetString(string key) =>
+            entries.TryGetValue(key, out var value) ? value : $"???{key}???";
+    }
+}

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml
@@ -20,6 +20,8 @@
       <NavigationViewItem Content="ObservableCollection Merge" Tag="ObservableCollectionMerge" Icon="List" />
       <NavigationViewItemHeader Content="Localization" />
       <NavigationViewItem Content="Localizer" Tag="Localizer" Icon="Globe" />
+      <NavigationViewItemHeader Content="Converters" />
+      <NavigationViewItem Content="Null + Enum Converters" Tag="NullEnumConverters" Icon="Switch" />
       <NavigationViewItemHeader Content="Infrastructure" />
       <NavigationViewItem Content="XamlRoot Provider" Tag="XamlRootProvider" Icon="Page" />
     </NavigationView.MenuItems>

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml.cs
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml.cs
@@ -31,6 +31,7 @@ public sealed partial class Shell : Page
                 "PackageVersion" => typeof(PackageVersionSamplePage),
                 "ObservableCollectionMerge" => typeof(ObservableCollectionMergeSamplePage),
                 "Localizer" => typeof(LocalizerSamplePage),
+                "NullEnumConverters" => typeof(NullEnumConvertersSamplePage),
                 "XamlRootProvider" => typeof(XamlRootProviderSamplePage),
                 _ => null
             };

--- a/src/MZikmund.Toolkit.WinUI/Converters/EnumLocalizationConverter.cs
+++ b/src/MZikmund.Toolkit.WinUI/Converters/EnumLocalizationConverter.cs
@@ -1,0 +1,38 @@
+using Microsoft.UI.Xaml.Data;
+using MZikmund.Toolkit.WinUI.Localization;
+
+namespace MZikmund.Toolkit.WinUI.Converters;
+
+/// <summary>
+/// Resolves an enum value to a localized string using the convention
+/// <c>{EnumType}_{EnumName}</c>, looked up through <see cref="Localizer.Current"/>.
+/// </summary>
+/// <remarks>
+/// Example: a <c>OrderStatus.Pending</c> value is resolved against the key
+/// <c>OrderStatus_Pending</c>. Apps can replace <see cref="Localizer.Current"/> at startup
+/// with their own implementation backed by <c>IStringLocalizer</c>.
+/// </remarks>
+public sealed class EnumLocalizationConverter : IValueConverter
+{
+    /// <inheritdoc />
+    public object Convert(object value, Type targetType, object parameter, string language)
+    {
+        if (value is null)
+        {
+            return string.Empty;
+        }
+
+        var type = value.GetType();
+        if (!type.IsEnum)
+        {
+            return value.ToString() ?? string.Empty;
+        }
+
+        var key = $"{type.Name}_{value}";
+        return Localizer.Current.GetString(key);
+    }
+
+    /// <inheritdoc />
+    public object ConvertBack(object value, Type targetType, object parameter, string language) =>
+        throw new NotSupportedException($"{nameof(EnumLocalizationConverter)} only supports one-way binding.");
+}

--- a/src/MZikmund.Toolkit.WinUI/Converters/NullToVisibilityConverter.cs
+++ b/src/MZikmund.Toolkit.WinUI/Converters/NullToVisibilityConverter.cs
@@ -1,0 +1,30 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Data;
+
+namespace MZikmund.Toolkit.WinUI.Converters;
+
+/// <summary>
+/// Maps an arbitrary object to a <see cref="Visibility"/>:
+/// non-null → <see cref="Visibility.Visible"/>, null → <see cref="Visibility.Collapsed"/>.
+/// Set <see cref="Invert"/> to swap that behavior.
+/// </summary>
+public sealed class NullToVisibilityConverter : IValueConverter
+{
+    /// <summary>
+    /// When <see langword="true"/>, null values become <see cref="Visibility.Visible"/>
+    /// and non-null values become <see cref="Visibility.Collapsed"/>.
+    /// </summary>
+    public bool Invert { get; set; }
+
+    /// <inheritdoc />
+    public object Convert(object value, Type targetType, object parameter, string language)
+    {
+        var hasValue = value is not null;
+        var visible = Invert ? !hasValue : hasValue;
+        return visible ? Visibility.Visible : Visibility.Collapsed;
+    }
+
+    /// <inheritdoc />
+    public object ConvertBack(object value, Type targetType, object parameter, string language) =>
+        throw new NotSupportedException($"{nameof(NullToVisibilityConverter)} only supports one-way binding.");
+}

--- a/tests/MZikmund.Toolkit.WinUI.Tests/EnumLocalizationConverterTests.cs
+++ b/tests/MZikmund.Toolkit.WinUI.Tests/EnumLocalizationConverterTests.cs
@@ -1,0 +1,99 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MZikmund.Toolkit.WinUI.Converters;
+using MZikmund.Toolkit.WinUI.Localization;
+
+namespace MZikmund.Toolkit.WinUI.Tests;
+
+[TestClass]
+public class EnumLocalizationConverterTests
+{
+    private static readonly EnumLocalizationConverter Converter = new();
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        Localizer.Current = new FallbackLocalizer();
+    }
+
+    [TestMethod]
+    public void Convert_KnownEnum_LocalizedThroughLocalizer()
+    {
+        Localizer.Current = new MapLocalizer(new()
+        {
+            ["OrderStatus_Pending"] = "Pending",
+            ["OrderStatus_Shipped"] = "Shipped",
+        });
+
+        Assert.AreEqual("Shipped", Converter.Convert(OrderStatus.Shipped, typeof(string), null!, null!));
+    }
+
+    [TestMethod]
+    public void Convert_UnknownKey_FallsBackToLocalizerFallback()
+    {
+        Localizer.Current = new FallbackLocalizer();
+
+        Assert.AreEqual("???OrderStatus_Cancelled???",
+            Converter.Convert(OrderStatus.Cancelled, typeof(string), null!, null!));
+    }
+
+    [TestMethod]
+    public void Convert_Null_ReturnsEmptyString()
+    {
+        Assert.AreEqual(string.Empty, Converter.Convert(null!, typeof(string), null!, null!));
+    }
+
+    [TestMethod]
+    public void Convert_NonEnum_FallsBackToToString()
+    {
+        Localizer.Current = new MapLocalizer(new());
+
+        Assert.AreEqual("hello", Converter.Convert("hello", typeof(string), null!, null!));
+    }
+
+    [TestMethod]
+    public void Convert_KeyConvention_UsesEnumTypeName()
+    {
+        var captured = new CaptureKey();
+        Localizer.Current = captured;
+
+        Converter.Convert(OrderStatus.Pending, typeof(string), null!, null!);
+
+        Assert.AreEqual("OrderStatus_Pending", captured.LastKey);
+    }
+
+    [TestMethod]
+    public void ConvertBack_NotSupported()
+    {
+        Assert.Throws<NotSupportedException>(() =>
+            Converter.ConvertBack("Pending", typeof(OrderStatus), null!, null!));
+    }
+
+    private enum OrderStatus
+    {
+        Pending,
+        Shipped,
+        Cancelled,
+    }
+
+    private sealed class FallbackLocalizer : ILocalizer
+    {
+        public string GetString(string key) => $"???{key}???";
+    }
+
+    private sealed class MapLocalizer(Dictionary<string, string> entries) : ILocalizer
+    {
+        public string GetString(string key) =>
+            entries.TryGetValue(key, out var value) ? value : $"???{key}???";
+    }
+
+    private sealed class CaptureKey : ILocalizer
+    {
+        public string? LastKey { get; private set; }
+
+        public string GetString(string key)
+        {
+            LastKey = key;
+            return key;
+        }
+    }
+}

--- a/tests/MZikmund.Toolkit.WinUI.Tests/NullToVisibilityConverterTests.cs
+++ b/tests/MZikmund.Toolkit.WinUI.Tests/NullToVisibilityConverterTests.cs
@@ -1,0 +1,59 @@
+using Microsoft.UI.Xaml;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MZikmund.Toolkit.WinUI.Converters;
+
+namespace MZikmund.Toolkit.WinUI.Tests;
+
+[TestClass]
+public class NullToVisibilityConverterTests
+{
+    [TestMethod]
+    public void Convert_NonNull_ReturnsVisible()
+    {
+        var converter = new NullToVisibilityConverter();
+
+        Assert.AreEqual(Visibility.Visible, converter.Convert("hi", typeof(Visibility), null!, null!));
+    }
+
+    [TestMethod]
+    public void Convert_Null_ReturnsCollapsed()
+    {
+        var converter = new NullToVisibilityConverter();
+
+        Assert.AreEqual(Visibility.Collapsed, converter.Convert(null!, typeof(Visibility), null!, null!));
+    }
+
+    [TestMethod]
+    public void Convert_Inverted_NullReturnsVisible()
+    {
+        var converter = new NullToVisibilityConverter { Invert = true };
+
+        Assert.AreEqual(Visibility.Visible, converter.Convert(null!, typeof(Visibility), null!, null!));
+    }
+
+    [TestMethod]
+    public void Convert_Inverted_NonNullReturnsCollapsed()
+    {
+        var converter = new NullToVisibilityConverter { Invert = true };
+
+        Assert.AreEqual(Visibility.Collapsed, converter.Convert("anything", typeof(Visibility), null!, null!));
+    }
+
+    [TestMethod]
+    public void Convert_EmptyString_TreatedAsNonNull()
+    {
+        // The converter checks reference null only — empty strings are still "have value".
+        var converter = new NullToVisibilityConverter();
+
+        Assert.AreEqual(Visibility.Visible, converter.Convert(string.Empty, typeof(Visibility), null!, null!));
+    }
+
+    [TestMethod]
+    public void ConvertBack_NotSupported()
+    {
+        var converter = new NullToVisibilityConverter();
+
+        Assert.Throws<NotSupportedException>(() =>
+            converter.ConvertBack(Visibility.Visible, typeof(object), null!, null!));
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `NullToVisibilityConverter` in `MZikmund.Toolkit.WinUI.Converters` — non-null → `Visibility.Visible`, null → `Visibility.Collapsed`. Has an `Invert` property to flip the mapping. One-way only.
- Adds `EnumLocalizationConverter` in the same namespace — resolves enum values through `Localizer.Current` using the convention `"{EnumType}_{Value}"`. Falls through to `ToString()` for non-enum input and returns empty string for `null`. One-way only.
- Wires a gallery sample (`NullEnumConvertersSamplePage`) into Shell + HomePage with two demos: a `TextBox.Text → Visibility` (and inverted variant) binding, and a 3-value `OrderStatus` enum with English/Czech dictionary localizers.
- Adds 12 unit tests across the two converters.

Closes #46

> **Stacked PR.** Targets `feature/issue-47-localizer` (#62) because `EnumLocalizationConverter` depends on `Localizer.Current`. Once #62 merges, retarget this to `main` (or to `feature/mergewith` first if that's still in flight).

## Test plan

- [x] `dotnet build MZikmund.Toolkit.slnx -c Debug` succeeds.
- [x] Test exe reports 29/29 passed (17 prior + 12 new).
- [ ] Manually exercise the `Null + Enum Converters` sample page on Windows: clear / type in the textbox and watch the two messages flip; click Pending / Shipped / Delivered and switch English / Czech to see the enum re-localize.

🤖 Generated with [Claude Code](https://claude.com/claude-code)