### PR TITLE
feat: Add DebugHttpHandler for logging unsuccessful HTTP responses

### DIFF
--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/DebugHttpHandlerSamplePage.xaml
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/DebugHttpHandlerSamplePage.xaml
@@ -1,0 +1,74 @@
+<Page x:Class="MZikmund.Toolkit.Sample.DebugHttpHandlerSamplePage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:local="using:MZikmund.Toolkit.Sample">
+
+  <ScrollViewer Padding="24">
+    <StackPanel Spacing="16" MaxWidth="800">
+      <TextBlock Text="DebugHttpHandler"
+                 Style="{ThemeResource TitleTextBlockStyle}" />
+
+      <TextBlock Text="A DelegatingHandler that logs unsuccessful HTTP responses (status, reason, body) without touching the response itself. Drop it on top of an HttpClient's handler chain in development builds and forget it exists until something fails."
+                 TextWrapping="Wrap"
+                 Style="{ThemeResource BodyTextBlockStyle}" />
+
+      <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+              BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+              BorderThickness="1"
+              CornerRadius="8"
+              Padding="16">
+        <StackPanel Spacing="12">
+          <TextBlock Text="Live demo"
+                     Style="{ThemeResource SubtitleTextBlockStyle}" />
+
+          <TextBlock Text="Each button sends a request through an HttpClient that has DebugHttpHandler at the top. The handler routes successful responses straight through and writes failures to a captured Log sink (visible below)."
+                     TextWrapping="Wrap"
+                     Style="{ThemeResource BodyTextBlockStyle}" />
+
+          <StackPanel Orientation="Horizontal" Spacing="8">
+            <Button Content="Send 200 OK" Click="SendOk_Click" Style="{ThemeResource AccentButtonStyle}" />
+            <Button Content="Send 404 Not Found" Click="SendNotFound_Click" />
+            <Button Content="Send 500 Server Error" Click="SendServerError_Click" />
+            <Button Content="Clear log" Click="Clear_Click" />
+          </StackPanel>
+
+          <TextBlock x:Name="LastResultText"
+                     Style="{ThemeResource BodyStrongTextBlockStyle}"
+                     Text="No request sent yet." />
+
+          <TextBlock Text="Captured failure log:"
+                     Style="{ThemeResource BodyStrongTextBlockStyle}" />
+          <Border BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                  BorderThickness="1"
+                  CornerRadius="4"
+                  Padding="8"
+                  MinHeight="120">
+            <TextBlock x:Name="LogText"
+                       FontFamily="Consolas"
+                       TextWrapping="Wrap"
+                       Text="(empty)" />
+          </Border>
+        </StackPanel>
+      </Border>
+
+      <Border Background="{ThemeResource LayerFillColorDefaultBrush}"
+              BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+              BorderThickness="1"
+              CornerRadius="8"
+              Padding="16">
+        <StackPanel Spacing="8">
+          <TextBlock Text="Code Sample"
+                     Style="{ThemeResource SubtitleTextBlockStyle}" />
+
+          <TextBlock FontFamily="Consolas" TextWrapping="Wrap">
+            <Run>using MZikmund.Toolkit.WinUI.Http;</Run><LineBreak />
+            <LineBreak />
+            <Run>var http = new HttpClient(new DebugHttpHandler(new HttpClientHandler()));</Run><LineBreak />
+            <Run>// or with HttpClientFactory:</Run><LineBreak />
+            <Run>// services.AddHttpClient&lt;Foo&gt;().AddHttpMessageHandler&lt;DebugHttpHandler&gt;();</Run>
+          </TextBlock>
+        </StackPanel>
+      </Border>
+    </StackPanel>
+  </ScrollViewer>
+</Page>

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/DebugHttpHandlerSamplePage.xaml.cs
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/DebugHttpHandlerSamplePage.xaml.cs
@@ -1,0 +1,79 @@
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using MZikmund.Toolkit.WinUI.Http;
+
+namespace MZikmund.Toolkit.Sample;
+
+public sealed partial class DebugHttpHandlerSamplePage : Page
+{
+    private readonly List<string> _capturedLog = new();
+    private readonly StubHttpHandler _stub = new();
+    private readonly HttpClient _client;
+
+    public DebugHttpHandlerSamplePage()
+    {
+        this.InitializeComponent();
+
+        var debugHandler = new DebugHttpHandler(_stub)
+        {
+            Log = message =>
+            {
+                _capturedLog.Add(message);
+                DispatcherQueue.TryEnqueue(UpdateLogText);
+            },
+        };
+        _client = new HttpClient(debugHandler);
+    }
+
+    private void SendOk_Click(object sender, RoutedEventArgs e) => _ = SendAsync(HttpStatusCode.OK, "Hello world");
+
+    private void SendNotFound_Click(object sender, RoutedEventArgs e) => _ = SendAsync(HttpStatusCode.NotFound, "{\"error\":\"not found\"}");
+
+    private void SendServerError_Click(object sender, RoutedEventArgs e) => _ = SendAsync(HttpStatusCode.InternalServerError, "boom");
+
+    private void Clear_Click(object sender, RoutedEventArgs e)
+    {
+        _capturedLog.Clear();
+        UpdateLogText();
+    }
+
+    private async Task SendAsync(HttpStatusCode statusCode, string body)
+    {
+        _stub.NextStatus = statusCode;
+        _stub.NextBody = body;
+
+        try
+        {
+            var response = await _client.GetAsync("https://example.test/api/sample");
+            LastResultText.Text = $"GET https://example.test/api/sample → {(int)response.StatusCode} {response.ReasonPhrase}";
+        }
+        catch (Exception ex)
+        {
+            LastResultText.Text = $"Request threw: {ex.Message}";
+        }
+    }
+
+    private void UpdateLogText()
+    {
+        LogText.Text = _capturedLog.Count == 0 ? "(empty)" : string.Join("\n\n", _capturedLog);
+    }
+
+    private sealed class StubHttpHandler : HttpMessageHandler
+    {
+        public HttpStatusCode NextStatus { get; set; } = HttpStatusCode.OK;
+
+        public string NextBody { get; set; } = string.Empty;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+            Task.FromResult(new HttpResponseMessage(NextStatus)
+            {
+                Content = new StringContent(NextBody),
+                RequestMessage = request,
+            });
+    }
+}

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/HomePage.xaml
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/HomePage.xaml
@@ -40,6 +40,12 @@
           <Run Text="ObservableCollection Merge:" FontWeight="SemiBold" />
           <Run Text=" MergeWith extension that synchronizes an ObservableCollection with a source list using minimal Insert/RemoveAt/Move operations." />
         </TextBlock>
+
+        <TextBlock Style="{ThemeResource BodyTextBlockStyle}">
+          <Run Text="• " FontWeight="Bold" />
+          <Run Text="Debug Http Handler:" FontWeight="SemiBold" />
+          <Run Text=" DelegatingHandler that logs unsuccessful HTTP responses (status, reason, body) for development builds." />
+        </TextBlock>
         
         <TextBlock Style="{ThemeResource BodyTextBlockStyle}">
           <Run Text="• " FontWeight="Bold" />

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml
@@ -18,6 +18,8 @@
       <NavigationViewItemHeader Content="Extensions" />
       <NavigationViewItem Content="Package Version" Tag="PackageVersion" Icon="Document" />
       <NavigationViewItem Content="ObservableCollection Merge" Tag="ObservableCollectionMerge" Icon="List" />
+      <NavigationViewItemHeader Content="Http" />
+      <NavigationViewItem Content="Debug Http Handler" Tag="DebugHttpHandler" Icon="World" />
       <NavigationViewItemHeader Content="Infrastructure" />
       <NavigationViewItem Content="XamlRoot Provider" Tag="XamlRootProvider" Icon="Page" />
     </NavigationView.MenuItems>

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml.cs
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml.cs
@@ -30,6 +30,7 @@ public sealed partial class Shell : Page
                 "DialogCoordinator" => typeof(DialogCoordinatorSamplePage),
                 "PackageVersion" => typeof(PackageVersionSamplePage),
                 "ObservableCollectionMerge" => typeof(ObservableCollectionMergeSamplePage),
+                "DebugHttpHandler" => typeof(DebugHttpHandlerSamplePage),
                 "XamlRootProvider" => typeof(XamlRootProviderSamplePage),
                 _ => null
             };

--- a/src/MZikmund.Toolkit.WinUI/Http/DebugHttpHandler.cs
+++ b/src/MZikmund.Toolkit.WinUI/Http/DebugHttpHandler.cs
@@ -1,0 +1,62 @@
+using System.Diagnostics;
+using System.Net.Http;
+using System.Threading;
+
+namespace MZikmund.Toolkit.WinUI.Http;
+
+/// <summary>
+/// <see cref="DelegatingHandler"/> that logs unsuccessful HTTP responses to a sink
+/// (defaulting to <see cref="Debug.WriteLine(string?)"/>). Intended to sit at the top
+/// of an <see cref="HttpClient"/>'s handler chain in development builds.
+/// </summary>
+/// <remarks>
+/// Successful responses pass through untouched. Failures are logged with method, URI,
+/// status code, reason phrase, and the response body. The body read is best-effort —
+/// failures while reading are caught and recorded as <c>"(unable to read body)"</c>
+/// so the handler never throws.
+/// </remarks>
+public sealed class DebugHttpHandler : DelegatingHandler
+{
+    /// <summary>
+    /// Sink for failure messages. Defaults to <see cref="Debug.WriteLine(string?)"/>.
+    /// Replace this in tests or to forward into a logging framework.
+    /// </summary>
+    public Action<string> Log { get; init; } = static message => Debug.WriteLine(message);
+
+    /// <summary>Initializes a new instance with no inner handler.</summary>
+    public DebugHttpHandler()
+    {
+    }
+
+    /// <summary>Initializes a new instance wrapping the supplied <paramref name="innerHandler"/>.</summary>
+    public DebugHttpHandler(HttpMessageHandler innerHandler)
+        : base(innerHandler)
+    {
+    }
+
+    /// <inheritdoc />
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var body = await TryReadBodyAsync(response, cancellationToken).ConfigureAwait(false);
+            Log($"[HTTP] {request.Method} {request.RequestUri} → {(int)response.StatusCode} {response.ReasonPhrase}{Environment.NewLine}{body}");
+        }
+
+        return response;
+    }
+
+    private static async Task<string> TryReadBodyAsync(HttpResponseMessage response, CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            return "(unable to read body)";
+        }
+    }
+}

--- a/tests/MZikmund.Toolkit.WinUI.Tests/DebugHttpHandlerTests.cs
+++ b/tests/MZikmund.Toolkit.WinUI.Tests/DebugHttpHandlerTests.cs
@@ -1,0 +1,93 @@
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MZikmund.Toolkit.WinUI.Http;
+
+namespace MZikmund.Toolkit.WinUI.Tests;
+
+[TestClass]
+public class DebugHttpHandlerTests
+{
+    [TestMethod]
+    public async Task Successful_Response_DoesNotLog()
+    {
+        var captured = new List<string>();
+        var stub = new StubHandler(HttpStatusCode.OK, "ok body");
+        using var client = new HttpClient(new DebugHttpHandler(stub)
+        {
+            Log = captured.Add,
+        });
+
+        var response = await client.GetAsync("https://example.test/");
+
+        Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+        Assert.AreEqual(0, captured.Count, "Successful responses must not be logged.");
+    }
+
+    [TestMethod]
+    public async Task Failure_Response_LogsMethodUriStatusAndBody()
+    {
+        var captured = new List<string>();
+        var stub = new StubHandler(HttpStatusCode.NotFound, "{\"error\":\"missing\"}");
+        using var client = new HttpClient(new DebugHttpHandler(stub)
+        {
+            Log = captured.Add,
+        });
+
+        await client.GetAsync("https://example.test/api/widgets/9");
+
+        Assert.AreEqual(1, captured.Count);
+        var entry = captured[0];
+        StringAssert.Contains(entry, "GET");
+        StringAssert.Contains(entry, "https://example.test/api/widgets/9");
+        StringAssert.Contains(entry, "404");
+        StringAssert.Contains(entry, "{\"error\":\"missing\"}");
+    }
+
+    [TestMethod]
+    public async Task Failure_Response_PassesResponseThroughUnchanged()
+    {
+        var stub = new StubHandler(HttpStatusCode.InternalServerError, "boom");
+        using var client = new HttpClient(new DebugHttpHandler(stub) { Log = _ => { } });
+
+        var response = await client.GetAsync("https://example.test/");
+
+        Assert.AreEqual(HttpStatusCode.InternalServerError, response.StatusCode);
+        Assert.AreEqual("boom", await response.Content.ReadAsStringAsync());
+    }
+
+    [TestMethod]
+    public async Task Multiple_Failures_LoggedSeparately()
+    {
+        var captured = new List<string>();
+        var stub = new StubHandler(HttpStatusCode.BadGateway, "x");
+        using var client = new HttpClient(new DebugHttpHandler(stub) { Log = captured.Add });
+
+        await client.GetAsync("https://example.test/a");
+        await client.GetAsync("https://example.test/b");
+
+        Assert.AreEqual(2, captured.Count);
+        StringAssert.Contains(captured[0], "/a");
+        StringAssert.Contains(captured[1], "/b");
+    }
+
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly HttpStatusCode _status;
+        private readonly string _body;
+
+        public StubHandler(HttpStatusCode status, string body)
+        {
+            _status = status;
+            _body = body;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+            Task.FromResult(new HttpResponseMessage(_status)
+            {
+                Content = new StringContent(_body ?? string.Empty),
+                RequestMessage = request,
+            });
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `DebugHttpHandler` in `MZikmund.Toolkit.WinUI.Http` — a `DelegatingHandler` that passes successful responses through untouched and logs failures (method, URI, status code, reason phrase, response body) to a configurable `Log` sink. Default sink is `Debug.WriteLine`. Body reads are best-effort and the handler never throws.
- Wires a gallery sample (`DebugHttpHandlerSamplePage`) into Shell + HomePage. Three buttons send requests through a stub message handler that returns 200 / 404 / 500, and the captured log is rendered live so you can see `Send 200 OK` produces nothing while the failures dump method / URI / status / body.
- Adds 4 unit tests covering: success doesn't log, failure logs the right fields, failure response passes through unchanged, and multiple failures get separate log entries.

Closes #48

> Stacked on top of #56 (the `MergeWith` PR). Rebase on `main` once #56 merges.

## Test plan

- [x] `dotnet build MZikmund.Toolkit.slnx -c Debug` succeeds.
- [x] Test exe reports 18/18 passed (14 prior + 4 new).
- [ ] Manually exercise the `Debug Http Handler` sample page on Windows: click `Send 200 OK` and confirm the captured log stays empty; click `Send 404` / `Send 500` and confirm the log shows method, URI, status, and body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)