### PR TITLE
feat: Add IDialogService and IConfirmationDialogService

### DIFF
--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/DialogServicesSamplePage.xaml
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/DialogServicesSamplePage.xaml
@@ -1,0 +1,87 @@
+<Page x:Class="MZikmund.Toolkit.Sample.DialogServicesSamplePage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:local="using:MZikmund.Toolkit.Sample">
+
+  <ScrollViewer Padding="24">
+    <StackPanel Spacing="16" MaxWidth="800">
+      <TextBlock Text="Dialog Services"
+                 Style="{ThemeResource TitleTextBlockStyle}" />
+
+      <TextBlock Text="IDialogService and IConfirmationDialogService wrap ContentDialog with auto XamlRoot injection (via IXamlRootProvider) and serialized show through IDialogCoordinator. Button labels default to English and can be overridden per-call or via DialogStrings."
+                 TextWrapping="Wrap"
+                 Style="{ThemeResource BodyTextBlockStyle}" />
+
+      <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+              BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+              BorderThickness="1"
+              CornerRadius="8"
+              Padding="16">
+        <StackPanel Spacing="12">
+          <TextBlock Text="IDialogService"
+                     Style="{ThemeResource SubtitleTextBlockStyle}" />
+
+          <TextBlock Text="Single-button informational dialog."
+                     TextWrapping="Wrap"
+                     Style="{ThemeResource BodyTextBlockStyle}" />
+
+          <StackPanel Orientation="Horizontal" Spacing="8">
+            <Button Content="Show info dialog" Click="ShowInfo_Click" Style="{ThemeResource AccentButtonStyle}" />
+            <Button Content="Show with custom button text" Click="ShowInfoCustom_Click" />
+          </StackPanel>
+        </StackPanel>
+      </Border>
+
+      <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+              BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+              BorderThickness="1"
+              CornerRadius="8"
+              Padding="16">
+        <StackPanel Spacing="12">
+          <TextBlock Text="IConfirmationDialogService"
+                     Style="{ThemeResource SubtitleTextBlockStyle}" />
+
+          <TextBlock Text="Yes/No confirmation. Returns ConfirmationResult.Yes or .No (Close = No)."
+                     TextWrapping="Wrap"
+                     Style="{ThemeResource BodyTextBlockStyle}" />
+
+          <StackPanel Orientation="Horizontal" Spacing="8">
+            <Button Content="Confirm (English)" Click="ConfirmEnglish_Click" Style="{ThemeResource AccentButtonStyle}" />
+            <Button Content="Confirm (Czech labels)" Click="ConfirmCzech_Click" />
+          </StackPanel>
+
+          <TextBlock x:Name="ConfirmResult"
+                     Style="{ThemeResource BodyStrongTextBlockStyle}"
+                     Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}"
+                     Text="No confirmation requested yet." />
+        </StackPanel>
+      </Border>
+
+      <Border Background="{ThemeResource LayerFillColorDefaultBrush}"
+              BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+              BorderThickness="1"
+              CornerRadius="8"
+              Padding="16">
+        <StackPanel Spacing="8">
+          <TextBlock Text="Code Sample"
+                     Style="{ThemeResource SubtitleTextBlockStyle}" />
+
+          <TextBlock FontFamily="Consolas" TextWrapping="Wrap">
+            <Run>using MZikmund.Toolkit.WinUI.Services;</Run><LineBreak />
+            <LineBreak />
+            <Run>// DI registration</Run><LineBreak />
+            <Run>services.AddSingleton&lt;IDialogCoordinator, DialogCoordinator&gt;();</Run><LineBreak />
+            <Run>services.AddSingleton&lt;IXamlRootProvider, MyXamlRootProvider&gt;();</Run><LineBreak />
+            <Run>services.AddSingleton&lt;IDialogService, DialogService&gt;();</Run><LineBreak />
+            <Run>services.AddSingleton&lt;IConfirmationDialogService, ConfirmationDialogService&gt;();</Run><LineBreak />
+            <LineBreak />
+            <Run>// Usage</Run><LineBreak />
+            <Run>await _dialogService.ShowAsync("Saved", "Your changes are saved.");</Run><LineBreak />
+            <Run>var result = await _confirmService.ConfirmAsync("Delete?", "This cannot be undone.");</Run><LineBreak />
+            <Run>if (result == ConfirmationResult.Yes) { /* ... */ }</Run>
+          </TextBlock>
+        </StackPanel>
+      </Border>
+    </StackPanel>
+  </ScrollViewer>
+</Page>

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/DialogServicesSamplePage.xaml.cs
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/DialogServicesSamplePage.xaml.cs
@@ -1,0 +1,50 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using MZikmund.Toolkit.WinUI.Infrastructure;
+using MZikmund.Toolkit.WinUI.Services;
+
+namespace MZikmund.Toolkit.Sample;
+
+public sealed partial class DialogServicesSamplePage : Page
+{
+    private readonly IDialogCoordinator _coordinator = new DialogCoordinator();
+
+    public DialogServicesSamplePage()
+    {
+        this.InitializeComponent();
+    }
+
+    private async void ShowInfo_Click(object sender, RoutedEventArgs e)
+    {
+        var dialogService = new DialogService(new ThisPageXamlRootProvider(this), _coordinator);
+        await dialogService.ShowAsync("Saved", "Your changes have been saved.");
+    }
+
+    private async void ShowInfoCustom_Click(object sender, RoutedEventArgs e)
+    {
+        var dialogService = new DialogService(new ThisPageXamlRootProvider(this), _coordinator);
+        await dialogService.ShowAsync("Custom button", "Notice the close button text below.", closeButtonText: "Got it");
+    }
+
+    private async void ConfirmEnglish_Click(object sender, RoutedEventArgs e)
+    {
+        var service = new ConfirmationDialogService(new ThisPageXamlRootProvider(this), _coordinator);
+        var result = await service.ConfirmAsync("Delete file?", "This cannot be undone.");
+        ConfirmResult.Text = $"Result: {result}";
+    }
+
+    private async void ConfirmCzech_Click(object sender, RoutedEventArgs e)
+    {
+        var service = new ConfirmationDialogService(
+            new ThisPageXamlRootProvider(this),
+            _coordinator,
+            new DialogStrings { YesButtonText = "Ano", NoButtonText = "Ne" });
+        var result = await service.ConfirmAsync("Smazat soubor?", "Tuto akci nelze vrátit zpět.");
+        ConfirmResult.Text = $"Result: {result}";
+    }
+
+    private sealed class ThisPageXamlRootProvider(Page page) : IXamlRootProvider
+    {
+        public XamlRoot XamlRoot => page.XamlRoot;
+    }
+}

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/HomePage.xaml
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/HomePage.xaml
@@ -28,6 +28,12 @@
           <Run Text="Dialog Coordinator:" FontWeight="SemiBold" />
           <Run Text=" Coordinates ContentDialog display to ensure only one dialog is shown at a time." />
         </TextBlock>
+
+        <TextBlock Style="{ThemeResource BodyTextBlockStyle}">
+          <Run Text="• " FontWeight="Bold" />
+          <Run Text="Dialog Services:" FontWeight="SemiBold" />
+          <Run Text=" IDialogService and IConfirmationDialogService — high-level wrappers over ContentDialog with auto XamlRoot injection and Yes/No confirmations." />
+        </TextBlock>
         
         <TextBlock Style="{ThemeResource BodyTextBlockStyle}">
           <Run Text="• " FontWeight="Bold" />

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml
@@ -15,6 +15,7 @@
       <NavigationViewItemHeader Content="Services" />
       <NavigationViewItem Content="Preferences" Tag="Preferences" Icon="Setting" />
       <NavigationViewItem Content="Dialog Coordinator" Tag="DialogCoordinator" Icon="Message" />
+      <NavigationViewItem Content="Dialog Services" Tag="DialogServices" Icon="Comment" />
       <NavigationViewItemHeader Content="Extensions" />
       <NavigationViewItem Content="Package Version" Tag="PackageVersion" Icon="Document" />
       <NavigationViewItem Content="ObservableCollection Merge" Tag="ObservableCollectionMerge" Icon="List" />

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml.cs
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml.cs
@@ -28,6 +28,7 @@ public sealed partial class Shell : Page
                 "Home" => typeof(HomePage),
                 "Preferences" => typeof(PreferencesSamplePage),
                 "DialogCoordinator" => typeof(DialogCoordinatorSamplePage),
+                "DialogServices" => typeof(DialogServicesSamplePage),
                 "PackageVersion" => typeof(PackageVersionSamplePage),
                 "ObservableCollectionMerge" => typeof(ObservableCollectionMergeSamplePage),
                 "XamlRootProvider" => typeof(XamlRootProviderSamplePage),

--- a/src/MZikmund.Toolkit.WinUI/Services/Dialogs/ConfirmationDialogService.cs
+++ b/src/MZikmund.Toolkit.WinUI/Services/Dialogs/ConfirmationDialogService.cs
@@ -1,0 +1,48 @@
+using MZikmund.Toolkit.WinUI.Infrastructure;
+
+namespace MZikmund.Toolkit.WinUI.Services;
+
+/// <summary>
+/// Default <see cref="IConfirmationDialogService"/> implementation. Builds a Yes/No
+/// <see cref="ContentDialog"/> with the primary button as the default and translates
+/// the result into <see cref="ConfirmationResult"/>.
+/// </summary>
+public class ConfirmationDialogService : IConfirmationDialogService
+{
+    private readonly IXamlRootProvider _xamlRootProvider;
+    private readonly IDialogCoordinator _coordinator;
+    private readonly DialogStrings _strings;
+
+    /// <summary>
+    /// Initializes a new instance.
+    /// </summary>
+    /// <param name="xamlRootProvider">Provider for the active <see cref="XamlRoot"/>.</param>
+    /// <param name="coordinator">Dialog coordinator that serializes concurrent shows.</param>
+    /// <param name="strings">Optional override for the default English button labels.</param>
+    public ConfirmationDialogService(
+        IXamlRootProvider xamlRootProvider,
+        IDialogCoordinator coordinator,
+        DialogStrings? strings = null)
+    {
+        _xamlRootProvider = xamlRootProvider;
+        _coordinator = coordinator;
+        _strings = strings ?? new DialogStrings();
+    }
+
+    /// <inheritdoc />
+    public async Task<ConfirmationResult> ConfirmAsync(string title, string message, string? yesText = null, string? noText = null)
+    {
+        var dialog = new ContentDialog
+        {
+            Title = title,
+            Content = message,
+            PrimaryButtonText = yesText ?? _strings.YesButtonText,
+            CloseButtonText = noText ?? _strings.NoButtonText,
+            DefaultButton = ContentDialogButton.Primary,
+            XamlRoot = _xamlRootProvider.XamlRoot,
+        };
+
+        var result = await _coordinator.ShowAsync(dialog);
+        return result == ContentDialogResult.Primary ? ConfirmationResult.Yes : ConfirmationResult.No;
+    }
+}

--- a/src/MZikmund.Toolkit.WinUI/Services/Dialogs/ConfirmationResult.cs
+++ b/src/MZikmund.Toolkit.WinUI/Services/Dialogs/ConfirmationResult.cs
@@ -1,0 +1,13 @@
+namespace MZikmund.Toolkit.WinUI.Services;
+
+/// <summary>
+/// Result of an <see cref="IConfirmationDialogService"/> prompt.
+/// </summary>
+public enum ConfirmationResult
+{
+    /// <summary>The user chose the affirmative option.</summary>
+    Yes,
+
+    /// <summary>The user chose the negative option (or dismissed the dialog).</summary>
+    No,
+}

--- a/src/MZikmund.Toolkit.WinUI/Services/Dialogs/DialogService.cs
+++ b/src/MZikmund.Toolkit.WinUI/Services/Dialogs/DialogService.cs
@@ -1,0 +1,45 @@
+using MZikmund.Toolkit.WinUI.Infrastructure;
+
+namespace MZikmund.Toolkit.WinUI.Services;
+
+/// <summary>
+/// Default <see cref="IDialogService"/> implementation. Builds a <see cref="ContentDialog"/>,
+/// attaches the current <see cref="XamlRoot"/> from <see cref="IXamlRootProvider"/>, and
+/// shows it through <see cref="IDialogCoordinator"/> so concurrent dialog requests are serialized.
+/// </summary>
+public class DialogService : IDialogService
+{
+    private readonly IXamlRootProvider _xamlRootProvider;
+    private readonly IDialogCoordinator _coordinator;
+    private readonly DialogStrings _strings;
+
+    /// <summary>
+    /// Initializes a new instance.
+    /// </summary>
+    /// <param name="xamlRootProvider">Provider for the active <see cref="XamlRoot"/>.</param>
+    /// <param name="coordinator">Dialog coordinator that serializes concurrent shows.</param>
+    /// <param name="strings">Optional override for the default English button labels.</param>
+    public DialogService(
+        IXamlRootProvider xamlRootProvider,
+        IDialogCoordinator coordinator,
+        DialogStrings? strings = null)
+    {
+        _xamlRootProvider = xamlRootProvider;
+        _coordinator = coordinator;
+        _strings = strings ?? new DialogStrings();
+    }
+
+    /// <inheritdoc />
+    public async Task ShowAsync(string title, string message, string? closeButtonText = null)
+    {
+        var dialog = new ContentDialog
+        {
+            Title = title,
+            Content = message,
+            CloseButtonText = closeButtonText ?? _strings.OkButtonText,
+            XamlRoot = _xamlRootProvider.XamlRoot,
+        };
+
+        await _coordinator.ShowAsync(dialog);
+    }
+}

--- a/src/MZikmund.Toolkit.WinUI/Services/Dialogs/DialogStrings.cs
+++ b/src/MZikmund.Toolkit.WinUI/Services/Dialogs/DialogStrings.cs
@@ -1,0 +1,23 @@
+namespace MZikmund.Toolkit.WinUI.Services;
+
+/// <summary>
+/// Localizable button labels used by <see cref="IDialogService"/> and <see cref="IConfirmationDialogService"/>.
+/// Defaults to English; apps can supply localized strings via the service constructors.
+/// </summary>
+public sealed class DialogStrings
+{
+    /// <summary>
+    /// Text used for the close button on a single-button dialog. Defaults to <c>"OK"</c>.
+    /// </summary>
+    public string OkButtonText { get; init; } = "OK";
+
+    /// <summary>
+    /// Text used for the affirmative button on a confirmation dialog. Defaults to <c>"Yes"</c>.
+    /// </summary>
+    public string YesButtonText { get; init; } = "Yes";
+
+    /// <summary>
+    /// Text used for the negative button on a confirmation dialog. Defaults to <c>"No"</c>.
+    /// </summary>
+    public string NoButtonText { get; init; } = "No";
+}

--- a/src/MZikmund.Toolkit.WinUI/Services/Dialogs/IConfirmationDialogService.cs
+++ b/src/MZikmund.Toolkit.WinUI/Services/Dialogs/IConfirmationDialogService.cs
@@ -1,0 +1,17 @@
+namespace MZikmund.Toolkit.WinUI.Services;
+
+/// <summary>
+/// Shows a Yes/No confirmation <see cref="ContentDialog"/>.
+/// </summary>
+public interface IConfirmationDialogService
+{
+    /// <summary>
+    /// Shows a confirmation dialog and returns the user's choice.
+    /// </summary>
+    /// <param name="title">Dialog title.</param>
+    /// <param name="message">Dialog message body.</param>
+    /// <param name="yesText">Override for the affirmative button text. Falls back to <see cref="DialogStrings.YesButtonText"/>.</param>
+    /// <param name="noText">Override for the negative button text. Falls back to <see cref="DialogStrings.NoButtonText"/>.</param>
+    /// <returns><see cref="ConfirmationResult.Yes"/> if the user clicked the primary button; otherwise <see cref="ConfirmationResult.No"/>.</returns>
+    Task<ConfirmationResult> ConfirmAsync(string title, string message, string? yesText = null, string? noText = null);
+}

--- a/src/MZikmund.Toolkit.WinUI/Services/Dialogs/IDialogService.cs
+++ b/src/MZikmund.Toolkit.WinUI/Services/Dialogs/IDialogService.cs
@@ -1,0 +1,15 @@
+namespace MZikmund.Toolkit.WinUI.Services;
+
+/// <summary>
+/// Shows a single-button informational <see cref="ContentDialog"/>.
+/// </summary>
+public interface IDialogService
+{
+    /// <summary>
+    /// Shows a dialog with the given title and message and a single close button.
+    /// </summary>
+    /// <param name="title">Dialog title.</param>
+    /// <param name="message">Dialog message body.</param>
+    /// <param name="closeButtonText">Override for the close button text. Falls back to <see cref="DialogStrings.OkButtonText"/>.</param>
+    Task ShowAsync(string title, string message, string? closeButtonText = null);
+}

--- a/tests/MZikmund.Toolkit.WinUI.Tests/DialogServicesTests.cs
+++ b/tests/MZikmund.Toolkit.WinUI.Tests/DialogServicesTests.cs
@@ -1,0 +1,46 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MZikmund.Toolkit.WinUI.Services;
+
+namespace MZikmund.Toolkit.WinUI.Tests;
+
+[TestClass]
+public class DialogServicesTests
+{
+    // The DialogService and ConfirmationDialogService construct ContentDialog instances,
+    // which is not possible in the headless test host (FrameworkElement requires a running
+    // XAML runtime). Service-level behavior is exercised manually through the sample page.
+    // These tests cover the support types only.
+
+    [TestMethod]
+    public void DialogStrings_Defaults_AreEnglish()
+    {
+        var strings = new DialogStrings();
+
+        Assert.AreEqual("OK", strings.OkButtonText);
+        Assert.AreEqual("Yes", strings.YesButtonText);
+        Assert.AreEqual("No", strings.NoButtonText);
+    }
+
+    [TestMethod]
+    public void DialogStrings_AreInitOnly_AndPreserveCustomValues()
+    {
+        var strings = new DialogStrings
+        {
+            OkButtonText = "Continuer",
+            YesButtonText = "Oui",
+            NoButtonText = "Non",
+        };
+
+        Assert.AreEqual("Continuer", strings.OkButtonText);
+        Assert.AreEqual("Oui", strings.YesButtonText);
+        Assert.AreEqual("Non", strings.NoButtonText);
+    }
+
+    [TestMethod]
+    public void ConfirmationResult_HasYesAndNoMembers()
+    {
+        // Sanity check that the public enum surface stays stable.
+        Assert.AreEqual(0, (int)ConfirmationResult.Yes);
+        Assert.AreEqual(1, (int)ConfirmationResult.No);
+    }
+}


### PR DESCRIPTION
## Summary

- Promotes the two dialog services from `uno-app-template` into `MZikmund.Toolkit.WinUI.Services`:
  - `IDialogService` / `DialogService` — single-button informational dialog. Auto-injects `XamlRoot` from `IXamlRootProvider` and shows through the existing `IDialogCoordinator` so concurrent calls serialize.
  - `IConfirmationDialogService` / `ConfirmationDialogService` / `ConfirmationResult` — Yes/No confirmation. `ContentDialogResult.Primary` → `Yes`; everything else (`None`, `Secondary`, dismiss) → `No`.
- Adds `DialogStrings` POCO with English defaults (`OK`/`Yes`/`No`). Apps can replace via the service constructor for a global default, or override per call with the optional method parameters.
- Wires a gallery sample (`DialogServicesSamplePage`) into Shell + HomePage with English info / custom-button info / Yes-No confirmation / Czech-labelled confirmation.
- Adds 3 tests covering `DialogStrings` defaults, init-only behavior, and the `ConfirmationResult` enum surface.

Service-level tests aren't possible headlessly — `ContentDialog` requires a running XAML runtime, so the sample page is the verification surface for those paths.

Closes #44

> Stacked on top of #56 (the `MergeWith` PR). Rebase on `main` once #56 merges.

## Test plan

- [x] `dotnet build MZikmund.Toolkit.slnx -c Debug` succeeds.
- [x] Test exe reports 17/17 passed (14 prior + 3 new).
- [ ] Manually exercise the `Dialog Services` sample page on Windows: show info dialog (default + custom close text), Yes/No confirmation in English, Czech-labelled confirmation. Confirm `Yes` and `No` results are reported correctly when clicking the primary button vs. dismissing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)