### PR TITLE
feat: Add ILocalizedDefinition pattern for keyed models

### DIFF
--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/HomePage.xaml
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/HomePage.xaml
@@ -46,6 +46,12 @@
           <Run Text="Localizer:" FontWeight="SemiBold" />
           <Run Text=" ILocalizer abstraction with static Localizer.Current accessor and a {Localize} XAML markup extension." />
         </TextBlock>
+
+        <TextBlock Style="{ThemeResource BodyTextBlockStyle}">
+          <Run Text="• " FontWeight="Bold" />
+          <Run Text="Localized Definitions:" FontWeight="SemiBold" />
+          <Run Text=" ILocalizedDefinition pattern for models that carry NameKey/DescriptionKey instead of hard-coded labels." />
+        </TextBlock>
         
         <TextBlock Style="{ThemeResource BodyTextBlockStyle}">
           <Run Text="• " FontWeight="Bold" />

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/LocalizedDefinitionsSamplePage.xaml
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/LocalizedDefinitionsSamplePage.xaml
@@ -1,0 +1,76 @@
+<Page x:Class="MZikmund.Toolkit.Sample.LocalizedDefinitionsSamplePage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:local="using:MZikmund.Toolkit.Sample">
+
+  <ScrollViewer Padding="24">
+    <StackPanel Spacing="16" MaxWidth="800">
+      <TextBlock Text="ILocalizedDefinition pattern"
+                 Style="{ThemeResource TitleTextBlockStyle}" />
+
+      <TextBlock Text="Models that carry localization keys (NameKey / DescriptionKey) instead of hard-coded labels can implement ILocalizedDefinition. The GetName / GetDescription extension methods then resolve those keys through ILocalizer (or Localizer.Current). Useful for achievement / definition / settings-option lists where each entry needs a localized title and subtitle."
+                 TextWrapping="Wrap"
+                 Style="{ThemeResource BodyTextBlockStyle}" />
+
+      <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+              BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+              BorderThickness="1"
+              CornerRadius="8"
+              Padding="16">
+        <StackPanel Spacing="12">
+          <TextBlock Text="Achievements"
+                     Style="{ThemeResource SubtitleTextBlockStyle}" />
+
+          <StackPanel Orientation="Horizontal" Spacing="8">
+            <Button Content="English" Click="UseEnglish_Click" Style="{ThemeResource AccentButtonStyle}" />
+            <Button Content="Czech" Click="UseCzech_Click" />
+          </StackPanel>
+
+          <ItemsControl x:Name="AchievementsList">
+            <ItemsControl.ItemTemplate>
+              <DataTemplate x:DataType="local:LocalizedAchievement">
+                <Border BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                        BorderThickness="1"
+                        CornerRadius="6"
+                        Padding="12"
+                        Margin="0,4">
+                  <StackPanel Spacing="2">
+                    <TextBlock Text="{x:Bind Name}"
+                               Style="{ThemeResource BodyStrongTextBlockStyle}" />
+                    <TextBlock Text="{x:Bind Description}"
+                               Style="{ThemeResource BodyTextBlockStyle}"
+                               TextWrapping="Wrap" />
+                  </StackPanel>
+                </Border>
+              </DataTemplate>
+            </ItemsControl.ItemTemplate>
+          </ItemsControl>
+        </StackPanel>
+      </Border>
+
+      <Border Background="{ThemeResource LayerFillColorDefaultBrush}"
+              BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+              BorderThickness="1"
+              CornerRadius="8"
+              Padding="16">
+        <StackPanel Spacing="8">
+          <TextBlock Text="Code Sample"
+                     Style="{ThemeResource SubtitleTextBlockStyle}" />
+
+          <TextBlock FontFamily="Consolas" TextWrapping="Wrap">
+            <Run>using MZikmund.Toolkit.WinUI.Localization;</Run><LineBreak />
+            <LineBreak />
+            <Run>public sealed record Achievement(string NameKey, string DescriptionKey)</Run><LineBreak />
+            <Run>    : ILocalizedDefinition;</Run><LineBreak />
+            <LineBreak />
+            <Run>// Resolve through Localizer.Current...</Run><LineBreak />
+            <Run>var displayName = achievement.GetName();</Run><LineBreak />
+            <LineBreak />
+            <Run>// ...or pass an ILocalizer explicitly when you have one in scope.</Run><LineBreak />
+            <Run>var description = achievement.GetDescription(localizer);</Run>
+          </TextBlock>
+        </StackPanel>
+      </Border>
+    </StackPanel>
+  </ScrollViewer>
+</Page>

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/LocalizedDefinitionsSamplePage.xaml.cs
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/LocalizedDefinitionsSamplePage.xaml.cs
@@ -1,0 +1,71 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using MZikmund.Toolkit.WinUI.Localization;
+
+namespace MZikmund.Toolkit.Sample;
+
+public sealed partial class LocalizedDefinitionsSamplePage : Page
+{
+    private static readonly DictionaryLocalizer English = new(new()
+    {
+        ["Achievement_FirstSteps_Name"] = "First Steps",
+        ["Achievement_FirstSteps_Description"] = "Complete the onboarding tutorial.",
+        ["Achievement_HabitFormed_Name"] = "Habit Formed",
+        ["Achievement_HabitFormed_Description"] = "Maintain a streak for 7 days in a row.",
+        ["Achievement_Marathon_Name"] = "Marathon",
+        ["Achievement_Marathon_Description"] = "Hit a 30-day streak. You're unstoppable.",
+    });
+
+    private static readonly DictionaryLocalizer Czech = new(new()
+    {
+        ["Achievement_FirstSteps_Name"] = "První kroky",
+        ["Achievement_FirstSteps_Description"] = "Dokončete úvodní průvodce.",
+        ["Achievement_HabitFormed_Name"] = "Návyk vytvořen",
+        ["Achievement_HabitFormed_Description"] = "Udržujte sérii 7 dní v řadě.",
+        ["Achievement_Marathon_Name"] = "Maraton",
+        ["Achievement_Marathon_Description"] = "Dosáhněte 30denní série. Jste nezastavitelní.",
+    });
+
+    private static readonly Achievement[] Definitions =
+    [
+        new("Achievement_FirstSteps_Name", "Achievement_FirstSteps_Description"),
+        new("Achievement_HabitFormed_Name", "Achievement_HabitFormed_Description"),
+        new("Achievement_Marathon_Name", "Achievement_Marathon_Description"),
+    ];
+
+    public LocalizedDefinitionsSamplePage()
+    {
+        Localizer.Current = English;
+        this.InitializeComponent();
+        Refresh();
+    }
+
+    private void UseEnglish_Click(object sender, RoutedEventArgs e)
+    {
+        Localizer.Current = English;
+        Refresh();
+    }
+
+    private void UseCzech_Click(object sender, RoutedEventArgs e)
+    {
+        Localizer.Current = Czech;
+        Refresh();
+    }
+
+    private void Refresh()
+    {
+        AchievementsList.ItemsSource = Definitions
+            .Select(d => new LocalizedAchievement(d.GetName(), d.GetDescription()))
+            .ToArray();
+    }
+
+    private sealed record Achievement(string NameKey, string DescriptionKey) : ILocalizedDefinition;
+
+    private sealed class DictionaryLocalizer(Dictionary<string, string> entries) : ILocalizer
+    {
+        public string GetString(string key) =>
+            entries.TryGetValue(key, out var value) ? value : $"???{key}???";
+    }
+}
+
+public sealed record LocalizedAchievement(string Name, string Description);

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml
@@ -20,6 +20,7 @@
       <NavigationViewItem Content="ObservableCollection Merge" Tag="ObservableCollectionMerge" Icon="List" />
       <NavigationViewItemHeader Content="Localization" />
       <NavigationViewItem Content="Localizer" Tag="Localizer" Icon="Globe" />
+      <NavigationViewItem Content="Localized Definitions" Tag="LocalizedDefinitions" Icon="Bookmarks" />
       <NavigationViewItemHeader Content="Infrastructure" />
       <NavigationViewItem Content="XamlRoot Provider" Tag="XamlRootProvider" Icon="Page" />
     </NavigationView.MenuItems>

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml.cs
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml.cs
@@ -31,6 +31,7 @@ public sealed partial class Shell : Page
                 "PackageVersion" => typeof(PackageVersionSamplePage),
                 "ObservableCollectionMerge" => typeof(ObservableCollectionMergeSamplePage),
                 "Localizer" => typeof(LocalizerSamplePage),
+                "LocalizedDefinitions" => typeof(LocalizedDefinitionsSamplePage),
                 "XamlRootProvider" => typeof(XamlRootProviderSamplePage),
                 _ => null
             };

--- a/src/MZikmund.Toolkit.WinUI/Localization/ILocalizedDefinition.cs
+++ b/src/MZikmund.Toolkit.WinUI/Localization/ILocalizedDefinition.cs
@@ -1,0 +1,25 @@
+namespace MZikmund.Toolkit.WinUI.Localization;
+
+/// <summary>
+/// Marks a model — typically an enum-like definition (achievement, settings option,
+/// game level, …) — that carries localization keys instead of hard-coded labels.
+/// </summary>
+/// <remarks>
+/// Pair with <see cref="LocalizedDefinitionExtensions.GetName(ILocalizedDefinition)"/> /
+/// <see cref="LocalizedDefinitionExtensions.GetDescription(ILocalizedDefinition)"/> to
+/// resolve through <see cref="Localizer.Current"/>, or with the overloads that take an
+/// <see cref="ILocalizer"/> directly when DI is preferred.
+/// </remarks>
+public interface ILocalizedDefinition
+{
+    /// <summary>
+    /// Resource key for the human-readable display name.
+    /// </summary>
+    string NameKey { get; }
+
+    /// <summary>
+    /// Resource key for the descriptive subtitle / longer text. Implementations may return
+    /// an empty string when no description applies.
+    /// </summary>
+    string DescriptionKey { get; }
+}

--- a/src/MZikmund.Toolkit.WinUI/Localization/LocalizedDefinitionExtensions.cs
+++ b/src/MZikmund.Toolkit.WinUI/Localization/LocalizedDefinitionExtensions.cs
@@ -1,0 +1,45 @@
+namespace MZikmund.Toolkit.WinUI.Localization;
+
+/// <summary>
+/// Convenience helpers for resolving <see cref="ILocalizedDefinition"/> keys through an
+/// <see cref="ILocalizer"/> (or the static <see cref="Localizer.Current"/>).
+/// </summary>
+public static class LocalizedDefinitionExtensions
+{
+    /// <summary>
+    /// Returns the localized display name for <paramref name="definition"/> using the supplied <paramref name="localizer"/>.
+    /// </summary>
+    public static string GetName(this ILocalizedDefinition definition, ILocalizer localizer)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+        ArgumentNullException.ThrowIfNull(localizer);
+        return localizer.GetString(definition.NameKey);
+    }
+
+    /// <summary>
+    /// Returns the localized description for <paramref name="definition"/> using the supplied <paramref name="localizer"/>.
+    /// Empty <see cref="ILocalizedDefinition.DescriptionKey"/> short-circuits to <see cref="string.Empty"/>.
+    /// </summary>
+    public static string GetDescription(this ILocalizedDefinition definition, ILocalizer localizer)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+        ArgumentNullException.ThrowIfNull(localizer);
+        return string.IsNullOrEmpty(definition.DescriptionKey)
+            ? string.Empty
+            : localizer.GetString(definition.DescriptionKey);
+    }
+
+    /// <summary>
+    /// Returns the localized display name through <see cref="Localizer.Current"/>.
+    /// Use the <see cref="GetName(ILocalizedDefinition, ILocalizer)"/> overload when DI is preferred.
+    /// </summary>
+    public static string GetName(this ILocalizedDefinition definition) =>
+        definition.GetName(Localizer.Current);
+
+    /// <summary>
+    /// Returns the localized description through <see cref="Localizer.Current"/>.
+    /// Use the <see cref="GetDescription(ILocalizedDefinition, ILocalizer)"/> overload when DI is preferred.
+    /// </summary>
+    public static string GetDescription(this ILocalizedDefinition definition) =>
+        definition.GetDescription(Localizer.Current);
+}

--- a/tests/MZikmund.Toolkit.WinUI.Tests/LocalizedDefinitionExtensionsTests.cs
+++ b/tests/MZikmund.Toolkit.WinUI.Tests/LocalizedDefinitionExtensionsTests.cs
@@ -1,0 +1,82 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MZikmund.Toolkit.WinUI.Localization;
+
+namespace MZikmund.Toolkit.WinUI.Tests;
+
+[TestClass]
+public class LocalizedDefinitionExtensionsTests
+{
+    private static readonly Definition Sample = new("Achievement_FirstSteps_Name", "Achievement_FirstSteps_Description");
+
+    [TestCleanup]
+    public void Cleanup() => Localizer.Current = new MapLocalizer(new());
+
+    [TestMethod]
+    public void GetName_WithExplicitLocalizer_ResolvesNameKey()
+    {
+        var localizer = new MapLocalizer(new() { ["Achievement_FirstSteps_Name"] = "First Steps" });
+
+        Assert.AreEqual("First Steps", Sample.GetName(localizer));
+    }
+
+    [TestMethod]
+    public void GetDescription_WithExplicitLocalizer_ResolvesDescriptionKey()
+    {
+        var localizer = new MapLocalizer(new() { ["Achievement_FirstSteps_Description"] = "Complete onboarding." });
+
+        Assert.AreEqual("Complete onboarding.", Sample.GetDescription(localizer));
+    }
+
+    [TestMethod]
+    public void GetName_WithoutArgument_UsesLocalizerCurrent()
+    {
+        Localizer.Current = new MapLocalizer(new() { ["Achievement_FirstSteps_Name"] = "Z static" });
+
+        Assert.AreEqual("Z static", Sample.GetName());
+    }
+
+    [TestMethod]
+    public void GetDescription_WithoutArgument_UsesLocalizerCurrent()
+    {
+        Localizer.Current = new MapLocalizer(new() { ["Achievement_FirstSteps_Description"] = "via Current" });
+
+        Assert.AreEqual("via Current", Sample.GetDescription());
+    }
+
+    [TestMethod]
+    public void GetDescription_EmptyDescriptionKey_ShortCircuitsToEmpty()
+    {
+        var noDesc = new Definition("name", string.Empty);
+        var localizer = new ThrowingLocalizer();
+
+        Assert.AreEqual(string.Empty, noDesc.GetDescription(localizer));
+        Assert.AreEqual(string.Empty, noDesc.GetDescription(localizer: localizer));
+    }
+
+    [TestMethod]
+    public void GetName_NullDefinition_Throws()
+    {
+        ILocalizedDefinition? def = null;
+
+        Assert.Throws<ArgumentNullException>(() => def!.GetName(new MapLocalizer(new())));
+    }
+
+    [TestMethod]
+    public void GetName_NullLocalizer_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => Sample.GetName(localizer: null!));
+    }
+
+    private sealed record Definition(string NameKey, string DescriptionKey) : ILocalizedDefinition;
+
+    private sealed class MapLocalizer(Dictionary<string, string> entries) : ILocalizer
+    {
+        public string GetString(string key) =>
+            entries.TryGetValue(key, out var value) ? value : $"???{key}???";
+    }
+
+    private sealed class ThrowingLocalizer : ILocalizer
+    {
+        public string GetString(string key) => throw new InvalidOperationException("Should not be called.");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `ILocalizedDefinition` interface in `MZikmund.Toolkit.WinUI.Localization` with `NameKey` and `DescriptionKey` properties.
- Adds `LocalizedDefinitionExtensions` with `GetName` / `GetDescription` extensions in two overloads each: one taking an explicit `ILocalizer` (for DI), one falling back to `Localizer.Current` (for places without DI). Empty `DescriptionKey` short-circuits to `string.Empty`.
- Wires a gallery sample (`LocalizedDefinitionsSamplePage`) into Shell + HomePage that renders three achievement records (`First Steps`, `Habit Formed`, `Marathon`) and swaps between English / Czech localizers.
- Adds 7 unit tests covering both overloads, the `Localizer.Current` fallback, the empty-description short-circuit, and null-arg guards.

Closes #40

> **Stacked PR.** Targets `feature/issue-47-localizer` (#62) because it depends on `ILocalizer` from #47. Once #62 merges, retarget to `main` (or `feature/mergewith` if that's still in flight).

## Test plan

- [x] `dotnet build MZikmund.Toolkit.slnx -c Debug` succeeds.
- [x] Test exe reports 24/24 passed (17 prior + 7 new).
- [ ] Manually exercise the `Localized Definitions` sample page on Windows: switch English / Czech and confirm all three achievements re-render with the localized name + description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)