### PR TITLE
feat: Add IAppRatingService with launch-count gating

### DIFF
--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/AppRatingSamplePage.xaml
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/AppRatingSamplePage.xaml
@@ -1,0 +1,91 @@
+<Page x:Class="MZikmund.Toolkit.Sample.AppRatingSamplePage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:local="using:MZikmund.Toolkit.Sample">
+
+  <ScrollViewer Padding="24">
+    <StackPanel Spacing="16" MaxWidth="800">
+      <TextBlock Text="IAppRatingService"
+                 Style="{ThemeResource TitleTextBlockStyle}" />
+
+      <TextBlock Text="IAppRatingService tracks app launches and prompts the user to rate once a threshold is reached. It persists state through IPreferences and routes the prompt to a per-platform store URI based on AppRatingOptions."
+                 TextWrapping="Wrap"
+                 Style="{ThemeResource BodyTextBlockStyle}" />
+
+      <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+              BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+              BorderThickness="1"
+              CornerRadius="8"
+              Padding="16">
+        <StackPanel Spacing="12">
+          <TextBlock Text="Live demo"
+                     Style="{ThemeResource SubtitleTextBlockStyle}" />
+
+          <TextBlock Text="The threshold for this demo is 3 launches. Click 'Increment' to simulate launches; once the threshold is reached the 'Should request rating?' state flips to true and Request Rating becomes meaningful."
+                     TextWrapping="Wrap"
+                     Style="{ThemeResource BodyTextBlockStyle}" />
+
+          <Grid ColumnSpacing="8" RowSpacing="8">
+            <Grid.ColumnDefinitions>
+              <ColumnDefinition Width="Auto" />
+              <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+              <RowDefinition Height="Auto" />
+              <RowDefinition Height="Auto" />
+              <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+
+            <TextBlock Grid.Row="0" Grid.Column="0" Text="Launch count:" FontWeight="SemiBold" />
+            <TextBlock Grid.Row="0" Grid.Column="1" x:Name="LaunchCountText" />
+
+            <TextBlock Grid.Row="1" Grid.Column="0" Text="Has been asked:" FontWeight="SemiBold" />
+            <TextBlock Grid.Row="1" Grid.Column="1" x:Name="HasBeenAskedText" />
+
+            <TextBlock Grid.Row="2" Grid.Column="0" Text="Should request rating?:" FontWeight="SemiBold" />
+            <TextBlock Grid.Row="2" Grid.Column="1" x:Name="ShouldRequestText" />
+          </Grid>
+
+          <StackPanel Orientation="Horizontal" Spacing="8">
+            <Button Content="Increment launch count" Click="Increment_Click" Style="{ThemeResource AccentButtonStyle}" />
+            <Button Content="Request rating" Click="Request_Click" />
+            <Button Content="Reset" Click="Reset_Click" />
+          </StackPanel>
+
+          <TextBlock x:Name="ResultText"
+                     TextWrapping="Wrap"
+                     Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}" />
+        </StackPanel>
+      </Border>
+
+      <Border Background="{ThemeResource LayerFillColorDefaultBrush}"
+              BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+              BorderThickness="1"
+              CornerRadius="8"
+              Padding="16">
+        <StackPanel Spacing="8">
+          <TextBlock Text="Code Sample"
+                     Style="{ThemeResource SubtitleTextBlockStyle}" />
+
+          <TextBlock FontFamily="Consolas" TextWrapping="Wrap">
+            <Run>using MZikmund.Toolkit.WinUI.Services;</Run><LineBreak />
+            <LineBreak />
+            <Run>var rating = new AppRatingService(preferences, new AppRatingOptions</Run><LineBreak />
+            <Run>{</Run><LineBreak />
+            <Run>    WindowsProductId = "9P1234567890",</Run><LineBreak />
+            <Run>    MinLaunchCountForRating = 5,</Run><LineBreak />
+            <Run>});</Run><LineBreak />
+            <LineBreak />
+            <Run>// On app start</Run><LineBreak />
+            <Run>rating.IncrementLaunchCount();</Run><LineBreak />
+            <LineBreak />
+            <Run>if (rating.ShouldRequestRating)</Run><LineBreak />
+            <Run>{</Run><LineBreak />
+            <Run>    await rating.RequestRatingAsync();</Run><LineBreak />
+            <Run>}</Run>
+          </TextBlock>
+        </StackPanel>
+      </Border>
+    </StackPanel>
+  </ScrollViewer>
+</Page>

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/AppRatingSamplePage.xaml.cs
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/AppRatingSamplePage.xaml.cs
@@ -1,0 +1,54 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using MZikmund.Toolkit.WinUI.Services;
+
+namespace MZikmund.Toolkit.Sample;
+
+public sealed partial class AppRatingSamplePage : Page
+{
+    private readonly IAppRatingService _service = new AppRatingService(
+        new Preferences(),
+        new AppRatingOptions
+        {
+            WindowsProductId = "9P1234567890",
+            AndroidPackageName = "com.example.app",
+            AppleAppId = "1234567890",
+            MinLaunchCountForRating = 3,
+        });
+
+    public AppRatingSamplePage()
+    {
+        this.InitializeComponent();
+        Refresh();
+    }
+
+    private void Increment_Click(object sender, RoutedEventArgs e)
+    {
+        _service.IncrementLaunchCount();
+        ResultText.Text = $"Launch count is now {_service.LaunchCount}.";
+        Refresh();
+    }
+
+    private async void Request_Click(object sender, RoutedEventArgs e)
+    {
+        var launched = await _service.RequestRatingAsync();
+        ResultText.Text = launched
+            ? "RequestRatingAsync launched the store URI."
+            : "RequestRatingAsync didn't launch — check that AppRatingOptions has an identifier for the current platform.";
+        Refresh();
+    }
+
+    private void Reset_Click(object sender, RoutedEventArgs e)
+    {
+        _service.Reset();
+        ResultText.Text = "Reset. Launch count and 'has been asked' are cleared.";
+        Refresh();
+    }
+
+    private void Refresh()
+    {
+        LaunchCountText.Text = _service.LaunchCount.ToString();
+        HasBeenAskedText.Text = _service.HasBeenAsked.ToString();
+        ShouldRequestText.Text = _service.ShouldRequestRating.ToString();
+    }
+}

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/HomePage.xaml
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/HomePage.xaml
@@ -28,6 +28,12 @@
           <Run Text="Dialog Coordinator:" FontWeight="SemiBold" />
           <Run Text=" Coordinates ContentDialog display to ensure only one dialog is shown at a time." />
         </TextBlock>
+
+        <TextBlock Style="{ThemeResource BodyTextBlockStyle}">
+          <Run Text="• " FontWeight="Bold" />
+          <Run Text="App Rating:" FontWeight="SemiBold" />
+          <Run Text=" Tracks launch count and prompts for a store rating once a configurable threshold is reached." />
+        </TextBlock>
         
         <TextBlock Style="{ThemeResource BodyTextBlockStyle}">
           <Run Text="• " FontWeight="Bold" />

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml
@@ -15,6 +15,7 @@
       <NavigationViewItemHeader Content="Services" />
       <NavigationViewItem Content="Preferences" Tag="Preferences" Icon="Setting" />
       <NavigationViewItem Content="Dialog Coordinator" Tag="DialogCoordinator" Icon="Message" />
+      <NavigationViewItem Content="App Rating" Tag="AppRating" Icon="Favorite" />
       <NavigationViewItemHeader Content="Extensions" />
       <NavigationViewItem Content="Package Version" Tag="PackageVersion" Icon="Document" />
       <NavigationViewItem Content="ObservableCollection Merge" Tag="ObservableCollectionMerge" Icon="List" />

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml.cs
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml.cs
@@ -28,6 +28,7 @@ public sealed partial class Shell : Page
                 "Home" => typeof(HomePage),
                 "Preferences" => typeof(PreferencesSamplePage),
                 "DialogCoordinator" => typeof(DialogCoordinatorSamplePage),
+                "AppRating" => typeof(AppRatingSamplePage),
                 "PackageVersion" => typeof(PackageVersionSamplePage),
                 "ObservableCollectionMerge" => typeof(ObservableCollectionMergeSamplePage),
                 "StableHash" => typeof(StableHashSamplePage),

--- a/src/MZikmund.Toolkit.WinUI/Services/Rating/AppRatingOptions.cs
+++ b/src/MZikmund.Toolkit.WinUI/Services/Rating/AppRatingOptions.cs
@@ -1,0 +1,23 @@
+namespace MZikmund.Toolkit.WinUI.Services;
+
+/// <summary>
+/// Configuration for <see cref="AppRatingService"/>: per-platform store identifiers
+/// and the launch-count threshold before the rating prompt is offered.
+/// </summary>
+public sealed class AppRatingOptions
+{
+    /// <summary>Microsoft Store product ID, used in <c>ms-windows-store://review/?ProductId=…</c>.</summary>
+    public string? WindowsProductId { get; init; }
+
+    /// <summary>Google Play package name, used in <c>market://details?id=…</c>.</summary>
+    public string? AndroidPackageName { get; init; }
+
+    /// <summary>Apple App Store app ID (numeric), used in <c>itms-apps://itunes.apple.com/app/id…?action=write-review</c>.</summary>
+    public string? AppleAppId { get; init; }
+
+    /// <summary>
+    /// Number of recorded launches required before <see cref="IAppRatingService.ShouldRequestRating"/>
+    /// flips to <see langword="true"/>. Defaults to <c>5</c>.
+    /// </summary>
+    public int MinLaunchCountForRating { get; init; } = 5;
+}

--- a/src/MZikmund.Toolkit.WinUI/Services/Rating/AppRatingService.cs
+++ b/src/MZikmund.Toolkit.WinUI/Services/Rating/AppRatingService.cs
@@ -1,0 +1,92 @@
+using Windows.System;
+
+namespace MZikmund.Toolkit.WinUI.Services;
+
+/// <summary>
+/// Default <see cref="IAppRatingService"/> implementation. Stores launch count and
+/// "has been asked" state through <see cref="IPreferences"/>, and dispatches the rating
+/// prompt to a platform-specific store URI through <see cref="Launcher.LaunchUriAsync(Uri)"/>.
+/// </summary>
+public class AppRatingService : IAppRatingService
+{
+    private const string LaunchCountKey = "AppRating.LaunchCount";
+    private const string HasBeenAskedKey = "AppRating.HasBeenAsked";
+
+    private readonly IPreferences _preferences;
+    private readonly AppRatingOptions _options;
+
+    /// <summary>Initializes a new instance.</summary>
+    public AppRatingService(IPreferences preferences, AppRatingOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(preferences);
+        ArgumentNullException.ThrowIfNull(options);
+        _preferences = preferences;
+        _options = options;
+    }
+
+    /// <inheritdoc />
+    public int LaunchCount => _preferences.Get(LaunchCountKey, 0);
+
+    /// <inheritdoc />
+    public bool HasBeenAsked => _preferences.Get(HasBeenAskedKey, false);
+
+    /// <inheritdoc />
+    public bool ShouldRequestRating =>
+        !HasBeenAsked && LaunchCount >= _options.MinLaunchCountForRating;
+
+    /// <inheritdoc />
+    public void IncrementLaunchCount() =>
+        _preferences.Set(LaunchCountKey, LaunchCount + 1);
+
+    /// <inheritdoc />
+    public async Task<bool> RequestRatingAsync()
+    {
+        var uri = GetReviewUri();
+        if (uri is null)
+        {
+            return false;
+        }
+
+        _preferences.Set(HasBeenAskedKey, true);
+        return await LaunchAsync(uri);
+    }
+
+    /// <inheritdoc />
+    public void Reset()
+    {
+        _preferences.Remove(LaunchCountKey);
+        _preferences.Remove(HasBeenAskedKey);
+    }
+
+    /// <summary>
+    /// Builds the platform-specific review URI for the current OS based on
+    /// <see cref="AppRatingOptions"/>. Returns <see langword="null"/> when the platform
+    /// is unsupported or the matching identifier is missing.
+    /// </summary>
+    /// <remarks>Override in tests to force a specific URI without depending on the host OS.</remarks>
+    protected virtual Uri? GetReviewUri()
+    {
+        if (OperatingSystem.IsWindows() && !string.IsNullOrEmpty(_options.WindowsProductId))
+        {
+            return new Uri($"ms-windows-store://review/?ProductId={_options.WindowsProductId}");
+        }
+
+        if (OperatingSystem.IsAndroid() && !string.IsNullOrEmpty(_options.AndroidPackageName))
+        {
+            return new Uri($"market://details?id={_options.AndroidPackageName}");
+        }
+
+        if ((OperatingSystem.IsIOS() || OperatingSystem.IsMacCatalyst()) && !string.IsNullOrEmpty(_options.AppleAppId))
+        {
+            return new Uri($"itms-apps://itunes.apple.com/app/id{_options.AppleAppId}?action=write-review");
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Hook used to actually launch the URI. Default implementation delegates to
+    /// <see cref="Launcher.LaunchUriAsync(Uri)"/>. Tests override this to capture the URI.
+    /// </summary>
+    protected virtual Task<bool> LaunchAsync(Uri uri) => Launcher.LaunchUriAsync(uri).AsTask();
+}

--- a/src/MZikmund.Toolkit.WinUI/Services/Rating/IAppRatingService.cs
+++ b/src/MZikmund.Toolkit.WinUI/Services/Rating/IAppRatingService.cs
@@ -1,0 +1,38 @@
+namespace MZikmund.Toolkit.WinUI.Services;
+
+/// <summary>
+/// Tracks app launch counts and prompts the user to rate the app once a threshold
+/// is reached. Pair with <see cref="AppRatingOptions"/> to configure the threshold
+/// and per-platform store identifiers.
+/// </summary>
+public interface IAppRatingService
+{
+    /// <summary>The number of recorded launches.</summary>
+    int LaunchCount { get; }
+
+    /// <summary><see langword="true"/> if the user has already been prompted to rate.</summary>
+    bool HasBeenAsked { get; }
+
+    /// <summary>
+    /// <see langword="true"/> when the launch threshold has been met and the user has
+    /// not yet been asked. Apps usually check this on app start and call
+    /// <see cref="RequestRatingAsync"/> if it's true.
+    /// </summary>
+    bool ShouldRequestRating { get; }
+
+    /// <summary>Increments the persisted launch counter. Call once per app launch.</summary>
+    void IncrementLaunchCount();
+
+    /// <summary>
+    /// Opens the platform's "rate this app" experience and records that the user
+    /// was asked. No-ops on platforms whose identifier is not configured.
+    /// </summary>
+    /// <returns><see langword="true"/> if the launcher accepted the request; otherwise <see langword="false"/>.</returns>
+    Task<bool> RequestRatingAsync();
+
+    /// <summary>
+    /// Resets <see cref="LaunchCount"/> and <see cref="HasBeenAsked"/>. Useful in tests
+    /// and as a "ask me again later" affordance.
+    /// </summary>
+    void Reset();
+}

--- a/tests/MZikmund.Toolkit.WinUI.Tests/AppRatingServiceTests.cs
+++ b/tests/MZikmund.Toolkit.WinUI.Tests/AppRatingServiceTests.cs
@@ -1,0 +1,174 @@
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MZikmund.Toolkit.WinUI.Services;
+
+namespace MZikmund.Toolkit.WinUI.Tests;
+
+[TestClass]
+public class AppRatingServiceTests
+{
+    [TestMethod]
+    public void Ctor_NullPreferences_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => new AppRatingService(null!, new AppRatingOptions()));
+    }
+
+    [TestMethod]
+    public void Ctor_NullOptions_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => new AppRatingService(new InMemoryPreferences(), null!));
+    }
+
+    [TestMethod]
+    public void LaunchCount_StartsAtZero_AndIncrements()
+    {
+        var service = new AppRatingService(new InMemoryPreferences(), new AppRatingOptions());
+
+        Assert.AreEqual(0, service.LaunchCount);
+        service.IncrementLaunchCount();
+        Assert.AreEqual(1, service.LaunchCount);
+        service.IncrementLaunchCount();
+        Assert.AreEqual(2, service.LaunchCount);
+    }
+
+    [TestMethod]
+    public void ShouldRequestRating_RespectsThreshold()
+    {
+        var service = new AppRatingService(
+            new InMemoryPreferences(),
+            new AppRatingOptions { MinLaunchCountForRating = 3 });
+
+        service.IncrementLaunchCount();
+        Assert.IsFalse(service.ShouldRequestRating);
+        service.IncrementLaunchCount();
+        Assert.IsFalse(service.ShouldRequestRating);
+        service.IncrementLaunchCount();
+        Assert.IsTrue(service.ShouldRequestRating);
+    }
+
+    [TestMethod]
+    public async Task RequestRatingAsync_FlipsHasBeenAsked_AndSuppressesShouldRequest()
+    {
+        var service = new TestableAppRatingService(
+            new InMemoryPreferences(),
+            new AppRatingOptions
+            {
+                WindowsProductId = "9P0",
+                MinLaunchCountForRating = 1,
+            });
+        service.IncrementLaunchCount();
+        Assert.IsTrue(service.ShouldRequestRating);
+
+        await service.RequestRatingAsync();
+
+        Assert.IsTrue(service.HasBeenAsked);
+        Assert.IsFalse(service.ShouldRequestRating);
+    }
+
+    [TestMethod]
+    public async Task RequestRatingAsync_NoUriForPlatform_DoesNotMarkAsAsked()
+    {
+        // No platform identifiers configured ⇒ GetReviewUri returns null ⇒ HasBeenAsked stays false.
+        var service = new TestableAppRatingService(
+            new InMemoryPreferences(),
+            new AppRatingOptions(),
+            forcedReviewUri: null);
+
+        var launched = await service.RequestRatingAsync();
+
+        Assert.IsFalse(launched);
+        Assert.IsFalse(service.HasBeenAsked);
+    }
+
+    [TestMethod]
+    public async Task RequestRatingAsync_PassesUriToLaunchHook()
+    {
+        var service = new TestableAppRatingService(
+            new InMemoryPreferences(),
+            new AppRatingOptions { WindowsProductId = "9P0" },
+            forcedReviewUri: new Uri("ms-windows-store://review/?ProductId=9P0"));
+
+        await service.RequestRatingAsync();
+
+        Assert.AreEqual("ms-windows-store://review/?ProductId=9P0", service.LastUri?.OriginalString);
+    }
+
+    [TestMethod]
+    public void Reset_ClearsLaunchCountAndAskedFlag()
+    {
+        var prefs = new InMemoryPreferences();
+        var service = new AppRatingService(prefs, new AppRatingOptions { MinLaunchCountForRating = 1 });
+        service.IncrementLaunchCount();
+        prefs.Set("AppRating.HasBeenAsked", true);
+
+        service.Reset();
+
+        Assert.AreEqual(0, service.LaunchCount);
+        Assert.IsFalse(service.HasBeenAsked);
+    }
+
+    private sealed class TestableAppRatingService : AppRatingService
+    {
+        private readonly Uri? _forcedUri;
+        private readonly bool _useForcedUri;
+
+        public Uri? LastUri { get; private set; }
+
+        public TestableAppRatingService(IPreferences preferences, AppRatingOptions options)
+            : base(preferences, options)
+        {
+        }
+
+        public TestableAppRatingService(IPreferences preferences, AppRatingOptions options, Uri? forcedReviewUri)
+            : base(preferences, options)
+        {
+            _forcedUri = forcedReviewUri;
+            _useForcedUri = true;
+        }
+
+        protected override Uri? GetReviewUri() => _useForcedUri ? _forcedUri : base.GetReviewUri();
+
+        protected override Task<bool> LaunchAsync(Uri uri)
+        {
+            LastUri = uri;
+            return Task.FromResult(true);
+        }
+    }
+
+    private sealed class InMemoryPreferences : IPreferences
+    {
+        private readonly Dictionary<string, object?> _values = new();
+
+        public T Get<T>(string key, T defaultValue) =>
+            _values.TryGetValue(key, out var v) && v is T typed ? typed : defaultValue;
+
+        public bool TryGet<T>(string key, [MaybeNullWhen(false)] out T value)
+        {
+            if (_values.TryGetValue(key, out var v) && v is T typed)
+            {
+                value = typed;
+                return true;
+            }
+            value = default;
+            return false;
+        }
+
+        public void Set<T>(string key, T? value)
+        {
+            if (value is null) _values.Remove(key);
+            else _values[key] = value;
+        }
+
+        public T GetComplex<T>(string key, T defaultValue) => Get(key, defaultValue);
+
+        public bool TryGetComplex<T>(string key, [MaybeNullWhen(false)] out T value) => TryGet(key, out value);
+
+        public void SetComplex<T>(string key, T? value) => Set(key, value);
+
+        public bool ContainsKey(string key) => _values.ContainsKey(key);
+
+        public void Remove(string key) => _values.Remove(key);
+
+        public void Clear() => _values.Clear();
+    }
+}


### PR DESCRIPTION
## Summary

Promotes the app-rating service from `uno-app-template` under `MZikmund.Toolkit.WinUI.Services`:

- `IAppRatingService` — `LaunchCount`, `HasBeenAsked`, `ShouldRequestRating`, `IncrementLaunchCount`, `RequestRatingAsync`, `Reset`.
- `AppRatingService` — persists state through `IPreferences`, builds the per-platform review URI from `AppRatingOptions` (Windows / Android / Apple) using `OperatingSystem` probes, and dispatches it through `Windows.System.Launcher.LaunchUriAsync`. Has `protected virtual` `GetReviewUri` / `LaunchAsync` hooks so tests can stub the platform-specific path.
- `AppRatingOptions` — `WindowsProductId`, `AndroidPackageName`, `AppleAppId`, `MinLaunchCountForRating` (default `5`).

`HasBeenAsked` is set inside `RequestRatingAsync` only when the URI lookup succeeds, so a misconfigured platform doesn't silently mark the user as already asked.

Wires a gallery sample (`AppRatingSamplePage`) into Shell + HomePage with an `Increment launch count` button, a `Request rating` button, and a `Reset` button. Live readout for `LaunchCount` / `HasBeenAsked` / `ShouldRequestRating`. Threshold is set to `3` for the demo.

Adds 8 unit tests covering null-arg guards, the launch counter, `ShouldRequestRating` gating, the `HasBeenAsked` flip on `RequestRatingAsync`, the no-URI-suppression behavior, hook invocation, and `Reset`. A dedicated `InMemoryPreferences` stub is used for `IPreferences`.

Closes #50

> **Stacked PR.** Targets `feature/issue-55-preferences-parity` (#60) because `AppRatingService.Reset()` calls `IPreferences.Remove` / `Clear` introduced in #55. Once #60 merges, retarget to `main` (or to `feature/mergewith` if that's still in flight).

## Test plan

- [x] `dotnet build MZikmund.Toolkit.slnx -c Debug` succeeds.
- [x] Test exe reports 22/22 passed (14 prior + 8 new).
- [ ] Manually exercise the `App Rating` sample on Windows: click `Increment` three times → `Should request rating?` flips to `True` at 3 launches; click `Request rating` → store URI launches and `HasBeenAsked` flips to `True`; click `Reset` → counters return to 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)