### PR TITLE
feat: Add IWindowShell + IWindowShellProvider infrastructure

### DIFF
--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/HomePage.xaml
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/HomePage.xaml
@@ -46,6 +46,12 @@
           <Run Text="XamlRoot Provider:" FontWeight="SemiBold" />
           <Run Text=" Provides centralized access to the XamlRoot instance for dialogs and popups." />
         </TextBlock>
+
+        <TextBlock Style="{ThemeResource BodyTextBlockStyle}">
+          <Run Text="• " FontWeight="Bold" />
+          <Run Text="Window Shell:" FontWeight="SemiBold" />
+          <Run Text=" IWindowShell + IWindowShellProvider abstraction for window-scoped infrastructure (theme manager, dialogs, navigation)." />
+        </TextBlock>
       </StackPanel>
       
       <TextBlock Text="Navigation"

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/WindowShellSamplePage.xaml
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/WindowShellSamplePage.xaml
@@ -1,0 +1,63 @@
+<Page x:Class="MZikmund.Toolkit.Sample.WindowShellSamplePage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:local="using:MZikmund.Toolkit.Sample">
+
+  <ScrollViewer Padding="24">
+    <StackPanel Spacing="16" MaxWidth="800">
+      <TextBlock Text="IWindowShell + IWindowShellProvider"
+                 Style="{ThemeResource TitleTextBlockStyle}" />
+
+      <TextBlock Text="IWindowShell is a generic abstraction over the per-window shell — view-model, XamlRoot, ServiceProvider, DispatcherQueue, RootFrame, and SetTitleBar. IWindowShellProvider exposes the active shell to services that need window-scoped access (theme manager, dialogs, navigation) without referencing the app's concrete shell type."
+                 TextWrapping="Wrap"
+                 Style="{ThemeResource BodyTextBlockStyle}" />
+
+      <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+              BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+              BorderThickness="1"
+              CornerRadius="8"
+              Padding="16">
+        <StackPanel Spacing="12">
+          <TextBlock Text="Live demo"
+                     Style="{ThemeResource SubtitleTextBlockStyle}" />
+
+          <TextBlock Text="The page registers a custom IWindowShell wrapping its own root frame and dispatcher with the WindowShellProvider, then queries the provider for the same shell instance."
+                     TextWrapping="Wrap"
+                     Style="{ThemeResource BodyTextBlockStyle}" />
+
+          <Button Content="Register and resolve" Click="RegisterAndResolve_Click" Style="{ThemeResource AccentButtonStyle}" />
+
+          <TextBlock x:Name="ResultText"
+                     TextWrapping="Wrap"
+                     FontFamily="Consolas"
+                     Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}"
+                     Text="Click the button to register a shell and read it back." />
+        </StackPanel>
+      </Border>
+
+      <Border Background="{ThemeResource LayerFillColorDefaultBrush}"
+              BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+              BorderThickness="1"
+              CornerRadius="8"
+              Padding="16">
+        <StackPanel Spacing="8">
+          <TextBlock Text="Code Sample"
+                     Style="{ThemeResource SubtitleTextBlockStyle}" />
+
+          <TextBlock FontFamily="Consolas" TextWrapping="Wrap">
+            <Run>using MZikmund.Toolkit.WinUI.Infrastructure;</Run><LineBreak />
+            <LineBreak />
+            <Run>// At app startup</Run><LineBreak />
+            <Run>services.AddSingleton&lt;IWindowShellProvider, WindowShellProvider&gt;();</Run><LineBreak />
+            <LineBreak />
+            <Run>// In your shell page constructor</Run><LineBreak />
+            <Run>provider.SetShell(this);  // 'this' implements IWindowShell</Run><LineBreak />
+            <LineBreak />
+            <Run>// Anywhere else</Run><LineBreak />
+            <Run>var dispatcher = _provider.Shell.DispatcherQueue;</Run>
+          </TextBlock>
+        </StackPanel>
+      </Border>
+    </StackPanel>
+  </ScrollViewer>
+</Page>

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/WindowShellSamplePage.xaml.cs
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/WindowShellSamplePage.xaml.cs
@@ -1,0 +1,51 @@
+using Microsoft.UI.Dispatching;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.Extensions.DependencyInjection;
+using MZikmund.Toolkit.WinUI.Infrastructure;
+
+namespace MZikmund.Toolkit.Sample;
+
+public sealed partial class WindowShellSamplePage : Page
+{
+    public WindowShellSamplePage()
+    {
+        this.InitializeComponent();
+    }
+
+    private void RegisterAndResolve_Click(object sender, RoutedEventArgs e)
+    {
+        var provider = new WindowShellProvider();
+        var shell = new InlineWindowShell(this);
+
+        provider.SetShell(shell);
+
+        var resolved = provider.Shell;
+        ResultText.Text =
+            $"Shell registered: same instance = {ReferenceEquals(shell, resolved)}\n" +
+            $"DispatcherQueue: {resolved.DispatcherQueue?.GetType().Name ?? "(null)"}\n" +
+            $"RootFrame: {resolved.RootFrame?.GetType().Name ?? "(null)"}\n" +
+            $"XamlRoot: {(resolved.XamlRoot is null ? "(null)" : "(set)")}\n" +
+            $"ServiceProvider: {(resolved.ServiceProvider is null ? "(null)" : "(set)")}\n" +
+            $"ViewModel: {resolved.ViewModel ?? "(null)"}";
+    }
+
+    private sealed class InlineWindowShell(Page page) : IWindowShell
+    {
+        public object? ViewModel => null;
+
+        public XamlRoot XamlRoot => page.XamlRoot;
+
+        public IServiceProvider ServiceProvider { get; } =
+            new ServiceCollection().BuildServiceProvider();
+
+        public DispatcherQueue DispatcherQueue => page.DispatcherQueue;
+
+        public Frame RootFrame => page.Frame;
+
+        public void SetTitleBar(UIElement titleBar)
+        {
+            // Sample shell doesn't own a Window — no-op.
+        }
+    }
+}

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml
@@ -20,6 +20,7 @@
       <NavigationViewItem Content="ObservableCollection Merge" Tag="ObservableCollectionMerge" Icon="List" />
       <NavigationViewItemHeader Content="Infrastructure" />
       <NavigationViewItem Content="XamlRoot Provider" Tag="XamlRootProvider" Icon="Page" />
+      <NavigationViewItem Content="Window Shell" Tag="WindowShell" Icon="NewWindow" />
     </NavigationView.MenuItems>
 
     <Frame x:Name="ContentFrame" />

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml.cs
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml.cs
@@ -31,6 +31,7 @@ public sealed partial class Shell : Page
                 "PackageVersion" => typeof(PackageVersionSamplePage),
                 "ObservableCollectionMerge" => typeof(ObservableCollectionMergeSamplePage),
                 "XamlRootProvider" => typeof(XamlRootProviderSamplePage),
+                "WindowShell" => typeof(WindowShellSamplePage),
                 _ => null
             };
 

--- a/src/MZikmund.Toolkit.WinUI/Infrastructure/IWindowShell.cs
+++ b/src/MZikmund.Toolkit.WinUI/Infrastructure/IWindowShell.cs
@@ -1,0 +1,34 @@
+using Microsoft.UI.Dispatching;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+namespace MZikmund.Toolkit.WinUI.Infrastructure;
+
+/// <summary>
+/// Generic abstraction for the per-window shell (the visual chrome plus the services
+/// scoped to it). Apps implement this on their actual window shell page; the toolkit
+/// uses it where it needs window-scoped access without depending on app-specific types.
+/// </summary>
+public interface IWindowShell
+{
+    /// <summary>The view-model bound to this shell. Apps choose the concrete type.</summary>
+    object? ViewModel { get; }
+
+    /// <summary>The active <see cref="XamlRoot"/> for this window.</summary>
+    XamlRoot XamlRoot { get; }
+
+    /// <summary>Per-window service provider scope. Pulled from the host's DI container.</summary>
+    IServiceProvider ServiceProvider { get; }
+
+    /// <summary>The <see cref="DispatcherQueue"/> that owns this window's UI thread.</summary>
+    DispatcherQueue DispatcherQueue { get; }
+
+    /// <summary>The frame that hosts top-level page navigation inside the shell.</summary>
+    Frame RootFrame { get; }
+
+    /// <summary>
+    /// Sets the custom title-bar element for this window (passes through to
+    /// <see cref="Window.SetTitleBar"/> on the owning window).
+    /// </summary>
+    void SetTitleBar(UIElement titleBar);
+}

--- a/src/MZikmund.Toolkit.WinUI/Infrastructure/IWindowShellProvider.cs
+++ b/src/MZikmund.Toolkit.WinUI/Infrastructure/IWindowShellProvider.cs
@@ -1,0 +1,21 @@
+namespace MZikmund.Toolkit.WinUI.Infrastructure;
+
+/// <summary>
+/// Resolves the active <see cref="IWindowShell"/> for the current window scope.
+/// Used by services that need window-scoped access (dialogs, theme manager, navigation)
+/// without holding a hard reference to the app's concrete shell type.
+/// </summary>
+public interface IWindowShellProvider
+{
+    /// <summary>
+    /// The active shell. Throws <see cref="InvalidOperationException"/> if no shell
+    /// has been registered through <see cref="SetShell"/> yet.
+    /// </summary>
+    IWindowShell Shell { get; }
+
+    /// <summary>
+    /// Registers (or replaces) the active shell. Apps call this once during shell
+    /// initialization, typically from the shell page's constructor or <c>OnLoaded</c>.
+    /// </summary>
+    void SetShell(IWindowShell shell);
+}

--- a/src/MZikmund.Toolkit.WinUI/Infrastructure/WindowShellProvider.cs
+++ b/src/MZikmund.Toolkit.WinUI/Infrastructure/WindowShellProvider.cs
@@ -1,0 +1,23 @@
+namespace MZikmund.Toolkit.WinUI.Infrastructure;
+
+/// <summary>
+/// Default <see cref="IWindowShellProvider"/> implementation. Holds a single
+/// <see cref="IWindowShell"/> reference set by the host on shell creation.
+/// Thread-safe for the simple "set once, read many" pattern.
+/// </summary>
+public class WindowShellProvider : IWindowShellProvider
+{
+    private IWindowShell? _shell;
+
+    /// <inheritdoc />
+    public IWindowShell Shell =>
+        _shell ?? throw new InvalidOperationException(
+            "No IWindowShell has been registered. Call SetShell during window initialization.");
+
+    /// <inheritdoc />
+    public void SetShell(IWindowShell shell)
+    {
+        ArgumentNullException.ThrowIfNull(shell);
+        _shell = shell;
+    }
+}

--- a/tests/MZikmund.Toolkit.WinUI.Tests/WindowShellProviderTests.cs
+++ b/tests/MZikmund.Toolkit.WinUI.Tests/WindowShellProviderTests.cs
@@ -1,0 +1,68 @@
+using Microsoft.UI.Dispatching;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MZikmund.Toolkit.WinUI.Infrastructure;
+
+namespace MZikmund.Toolkit.WinUI.Tests;
+
+[TestClass]
+public class WindowShellProviderTests
+{
+    [TestMethod]
+    public void Shell_BeforeSetShell_Throws()
+    {
+        var provider = new WindowShellProvider();
+
+        Assert.Throws<InvalidOperationException>(() => _ = provider.Shell);
+    }
+
+    [TestMethod]
+    public void SetShell_Null_Throws()
+    {
+        var provider = new WindowShellProvider();
+
+        Assert.Throws<ArgumentNullException>(() => provider.SetShell(null!));
+    }
+
+    [TestMethod]
+    public void SetShell_RegistersInstance_AndShellReturnsSame()
+    {
+        var provider = new WindowShellProvider();
+        var shell = new StubShell();
+
+        provider.SetShell(shell);
+
+        Assert.AreSame(shell, provider.Shell);
+    }
+
+    [TestMethod]
+    public void SetShell_Replace_OverwritesPreviousInstance()
+    {
+        var provider = new WindowShellProvider();
+        var first = new StubShell();
+        var second = new StubShell();
+
+        provider.SetShell(first);
+        provider.SetShell(second);
+
+        Assert.AreSame(second, provider.Shell);
+    }
+
+    private sealed class StubShell : IWindowShell
+    {
+        public object? ViewModel => null;
+
+        public XamlRoot XamlRoot => null!;
+
+        public IServiceProvider ServiceProvider => null!;
+
+        public DispatcherQueue DispatcherQueue => null!;
+
+        public Frame RootFrame => null!;
+
+        public void SetTitleBar(UIElement titleBar)
+        {
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Promotes the per-window shell abstraction from `uno-app-template` under `MZikmund.Toolkit.WinUI.Infrastructure`:

- `IWindowShell` — generic shell abstraction with `ViewModel`, `XamlRoot`, `ServiceProvider`, `DispatcherQueue`, `RootFrame`, and `SetTitleBar`. Apps implement this on their concrete shell page.
- `IWindowShellProvider` — read/write accessor for the active shell. Pulled by services that need window-scoped access without depending on app-specific types.
- `WindowShellProvider` — default impl. Throws `InvalidOperationException` if `Shell` is read before `SetShell`, throws `ArgumentNullException` on `SetShell(null)`, and supports replacement (last write wins).

Wires a gallery sample (`WindowShellSamplePage`) into Shell + HomePage that creates an inline `IWindowShell` wrapping the page's own `XamlRoot` / `Frame` / `DispatcherQueue`, registers it with a `WindowShellProvider`, and reads it back to verify identity.

Adds 4 unit tests covering the throw-before-set, null-arg, set-and-resolve, and replacement paths against a stub `IWindowShell`.

This is the landing pad for the ThemeManager (#49), navigation infrastructure (#52), and other template-promotion issues that need window-scoped access.

Closes #51

> Stacked on top of #56 (the `MergeWith` PR). Rebase on `main` once #56 merges.

## Test plan

- [x] `dotnet build MZikmund.Toolkit.slnx -c Debug` succeeds.
- [x] Test exe reports 18/18 passed (14 prior + 4 new).
- [ ] Manually exercise the `Window Shell` sample on Windows: click `Register and resolve`, confirm the resolved shell is the same instance and that `DispatcherQueue` / `RootFrame` / `XamlRoot` / `ServiceProvider` are populated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)