### PR TITLE
feat: Add UIElement.GetServiceProvider extension

### DIFF
--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/HomePage.xaml
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/HomePage.xaml
@@ -49,6 +49,12 @@
 
         <TextBlock Style="{ThemeResource BodyTextBlockStyle}">
           <Run Text="• " FontWeight="Bold" />
+          <Run Text="UIElement Services:" FontWeight="SemiBold" />
+          <Run Text=" UIElement.GetServiceProvider() walks the visual tree to find the parent IWindowShell's DI scope." />
+        </TextBlock>
+
+        <TextBlock Style="{ThemeResource BodyTextBlockStyle}">
+          <Run Text="• " FontWeight="Bold" />
           <Run Text="Window Shell:" FontWeight="SemiBold" />
           <Run Text=" IWindowShell + IWindowShellProvider abstraction for window-scoped infrastructure (theme manager, dialogs, navigation)." />
         </TextBlock>

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/UIElementServicesSamplePage.xaml
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/UIElementServicesSamplePage.xaml
@@ -1,0 +1,64 @@
+<Page x:Class="MZikmund.Toolkit.Sample.UIElementServicesSamplePage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:local="using:MZikmund.Toolkit.Sample">
+
+  <ScrollViewer Padding="24">
+    <StackPanel Spacing="16" MaxWidth="800">
+      <TextBlock Text="UIElement.GetServiceProvider"
+                 Style="{ThemeResource TitleTextBlockStyle}" />
+
+      <TextBlock Text="UIElement.GetServiceProvider() walks the visual tree up from the element, finds the first IWindowShell ancestor, and returns its DI ServiceProvider. Useful in event handlers, behaviors, and converters where constructor injection isn't available."
+                 TextWrapping="Wrap"
+                 Style="{ThemeResource BodyTextBlockStyle}" />
+
+      <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+              BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+              BorderThickness="1"
+              CornerRadius="8"
+              Padding="16">
+        <StackPanel Spacing="12">
+          <TextBlock Text="Live demo"
+                     Style="{ThemeResource SubtitleTextBlockStyle}" />
+
+          <TextBlock Text="The page itself implements IWindowShell with a small DI container holding a sample ITimeProvider service. Clicking the button calls element.GetServiceProvider() and resolves ITimeProvider from there."
+                     TextWrapping="Wrap"
+                     Style="{ThemeResource BodyTextBlockStyle}" />
+
+          <Button x:Name="ResolveButton"
+                  Content="Resolve service from this button"
+                  Click="Resolve_Click"
+                  Style="{ThemeResource AccentButtonStyle}" />
+
+          <TextBlock x:Name="ResultText"
+                     TextWrapping="Wrap"
+                     FontFamily="Consolas"
+                     Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}"
+                     Text="No call yet." />
+        </StackPanel>
+      </Border>
+
+      <Border Background="{ThemeResource LayerFillColorDefaultBrush}"
+              BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+              BorderThickness="1"
+              CornerRadius="8"
+              Padding="16">
+        <StackPanel Spacing="8">
+          <TextBlock Text="Code Sample"
+                     Style="{ThemeResource SubtitleTextBlockStyle}" />
+
+          <TextBlock FontFamily="Consolas" TextWrapping="Wrap">
+            <Run>using MZikmund.Toolkit.WinUI.Extensions;</Run><LineBreak />
+            <LineBreak />
+            <Run>private void OnButtonClick(object sender, RoutedEventArgs e)</Run><LineBreak />
+            <Run>{</Run><LineBreak />
+            <Run>    var services = ((Button)sender).GetServiceProvider();</Run><LineBreak />
+            <Run>    var dialog = services.GetRequiredService&lt;IDialogService&gt;();</Run><LineBreak />
+            <Run>    await dialog.ShowAsync("Hello", "Resolved through the visual tree.");</Run><LineBreak />
+            <Run>}</Run>
+          </TextBlock>
+        </StackPanel>
+      </Border>
+    </StackPanel>
+  </ScrollViewer>
+</Page>

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/UIElementServicesSamplePage.xaml.cs
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/UIElementServicesSamplePage.xaml.cs
@@ -1,0 +1,58 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.UI.Dispatching;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using MZikmund.Toolkit.WinUI.Extensions;
+using MZikmund.Toolkit.WinUI.Infrastructure;
+
+namespace MZikmund.Toolkit.Sample;
+
+public sealed partial class UIElementServicesSamplePage : Page, IWindowShell
+{
+    public UIElementServicesSamplePage()
+    {
+        this.InitializeComponent();
+
+        ServiceProvider = new ServiceCollection()
+            .AddSingleton<ITimeProvider, SystemTimeProvider>()
+            .BuildServiceProvider();
+    }
+
+    public object? ViewModel => null;
+
+    public new XamlRoot XamlRoot => base.XamlRoot;
+
+    public IServiceProvider ServiceProvider { get; }
+
+    public new DispatcherQueue DispatcherQueue => base.DispatcherQueue;
+
+    public Frame RootFrame => Frame;
+
+    public void SetTitleBar(UIElement titleBar)
+    {
+    }
+
+    private void Resolve_Click(object sender, RoutedEventArgs e)
+    {
+        try
+        {
+            var services = ((Button)sender).GetServiceProvider();
+            var time = services.GetRequiredService<ITimeProvider>();
+            ResultText.Text = $"Resolved ITimeProvider → {time.Now:O}";
+        }
+        catch (Exception ex)
+        {
+            ResultText.Text = $"Failed: {ex.Message}";
+        }
+    }
+
+    private interface ITimeProvider
+    {
+        DateTimeOffset Now { get; }
+    }
+
+    private sealed class SystemTimeProvider : ITimeProvider
+    {
+        public DateTimeOffset Now => DateTimeOffset.UtcNow;
+    }
+}

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml
@@ -20,6 +20,7 @@
       <NavigationViewItem Content="ObservableCollection Merge" Tag="ObservableCollectionMerge" Icon="List" />
       <NavigationViewItemHeader Content="Infrastructure" />
       <NavigationViewItem Content="XamlRoot Provider" Tag="XamlRootProvider" Icon="Page" />
+      <NavigationViewItem Content="UIElement Services" Tag="UIElementServices" Icon="Link" />
       <NavigationViewItem Content="Window Shell" Tag="WindowShell" Icon="NewWindow" />
     </NavigationView.MenuItems>
 

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml.cs
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml.cs
@@ -31,6 +31,7 @@ public sealed partial class Shell : Page
                 "PackageVersion" => typeof(PackageVersionSamplePage),
                 "ObservableCollectionMerge" => typeof(ObservableCollectionMergeSamplePage),
                 "XamlRootProvider" => typeof(XamlRootProviderSamplePage),
+                "UIElementServices" => typeof(UIElementServicesSamplePage),
                 "WindowShell" => typeof(WindowShellSamplePage),
                 _ => null
             };

--- a/src/MZikmund.Toolkit.WinUI/Extensions/UIElementExtensions.cs
+++ b/src/MZikmund.Toolkit.WinUI/Extensions/UIElementExtensions.cs
@@ -1,0 +1,57 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Media;
+using MZikmund.Toolkit.WinUI.Infrastructure;
+
+namespace MZikmund.Toolkit.WinUI.Extensions;
+
+/// <summary>
+/// Extensions for <see cref="UIElement"/> that bridge into toolkit infrastructure.
+/// </summary>
+public static class UIElementExtensions
+{
+    /// <summary>
+    /// Walks up the visual tree from <paramref name="element"/> looking for an ancestor
+    /// (or the element itself) that implements <see cref="IWindowShell"/>, and returns
+    /// that shell's <see cref="IWindowShell.ServiceProvider"/>.
+    /// </summary>
+    /// <param name="element">Starting element.</param>
+    /// <returns>The DI scope tied to the owning shell.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="element"/> is <see langword="null"/>.</exception>
+    /// <exception cref="InvalidOperationException">No <see cref="IWindowShell"/> ancestor was found.</exception>
+    /// <remarks>
+    /// Useful in event handlers, attached behaviors, and any other code-behind path where
+    /// constructor injection isn't available — you have a UI element in hand and need to
+    /// reach the same DI scope the rest of the window uses.
+    /// </remarks>
+    public static IServiceProvider GetServiceProvider(this UIElement element)
+    {
+        ArgumentNullException.ThrowIfNull(element);
+
+        return element.TryGetServiceProvider()
+            ?? throw new InvalidOperationException(
+                "No IWindowShell ancestor was found in the visual tree. Ensure the element is hosted inside a window shell that implements IWindowShell.");
+    }
+
+    /// <summary>
+    /// Non-throwing variant of <see cref="GetServiceProvider(UIElement)"/>. Returns
+    /// <see langword="null"/> when no <see cref="IWindowShell"/> ancestor is found, which
+    /// can happen during construction or when the element is detached.
+    /// </summary>
+    public static IServiceProvider? TryGetServiceProvider(this UIElement element)
+    {
+        ArgumentNullException.ThrowIfNull(element);
+
+        DependencyObject? current = element;
+        while (current is not null)
+        {
+            if (current is IWindowShell shell)
+            {
+                return shell.ServiceProvider;
+            }
+
+            current = VisualTreeHelper.GetParent(current);
+        }
+
+        return null;
+    }
+}

--- a/tests/MZikmund.Toolkit.WinUI.Tests/UIElementExtensionsTests.cs
+++ b/tests/MZikmund.Toolkit.WinUI.Tests/UIElementExtensionsTests.cs
@@ -1,0 +1,29 @@
+using Microsoft.UI.Xaml;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MZikmund.Toolkit.WinUI.Extensions;
+
+namespace MZikmund.Toolkit.WinUI.Tests;
+
+[TestClass]
+public class UIElementExtensionsTests
+{
+    // The visual-tree walk relies on VisualTreeHelper, which requires a running XAML
+    // host. Headless tests can only cover the null-arg guards; happy-path lookup is
+    // verified manually through the sample gallery page.
+
+    [TestMethod]
+    public void GetServiceProvider_NullElement_Throws()
+    {
+        UIElement? element = null;
+
+        Assert.Throws<ArgumentNullException>(() => element!.GetServiceProvider());
+    }
+
+    [TestMethod]
+    public void TryGetServiceProvider_NullElement_Throws()
+    {
+        UIElement? element = null;
+
+        Assert.Throws<ArgumentNullException>(() => element!.TryGetServiceProvider());
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `UIElement.GetServiceProvider()` and `UIElement.TryGetServiceProvider()` in `MZikmund.Toolkit.WinUI.Extensions`. Both walk the visual tree (via `VisualTreeHelper.GetParent`) looking for an `IWindowShell` ancestor (or the element itself) and return that shell's DI scope.
- Throwing variant: `InvalidOperationException` with a clear "Ensure the element is hosted inside a window shell that implements IWindowShell" message when nothing matches.
- Try variant: returns `null` for "no shell found yet" scenarios (construction time, detached elements).
- Both guard against a null element argument.
- Wires a gallery sample (`UIElementServicesSamplePage`) into Shell + HomePage. The sample page itself implements `IWindowShell` with a small DI container holding an `ITimeProvider`. A button uses `((Button)sender).GetServiceProvider().GetRequiredService<ITimeProvider>()` to resolve through the visual-tree walk.
- Adds 2 unit tests for the null-arg guards. The visual-tree walk requires a XAML host and is verified through the sample.

Closes #32

> **Stacked PR.** Targets `feature/issue-51-window-shell` (#70) because this depends on `IWindowShell`. Once #70 merges, retarget to `main` (or to `feature/mergewith` first if it's still in flight).

## Test plan

- [x] `dotnet build MZikmund.Toolkit.slnx -c Debug` succeeds.
- [x] Test exe reports 20/20 passed (18 prior + 2 new).
- [ ] Manually exercise the `UIElement Services` sample page on Windows: click `Resolve`, verify the result text shows the resolved `ITimeProvider` timestamp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)