### PR TITLE
feat: Add ILoadingIndicator with reference-counted scopes

### DIFF
--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/HomePage.xaml
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/HomePage.xaml
@@ -58,6 +58,12 @@
           <Run Text="Core Infrastructure:" FontWeight="SemiBold" />
           <Run Text=" ObservableObject, RelayCommand, ViewModelBase, WindowShellViewModel, IoC service-locator, IAppUpdater hook." />
         </TextBlock>
+
+        <TextBlock Style="{ThemeResource BodyTextBlockStyle}">
+          <Run Text="• " FontWeight="Bold" />
+          <Run Text="Loading Indicator:" FontWeight="SemiBold" />
+          <Run Text=" ILoadingIndicator with reference-counted BeginLoading scopes for app-wide loading UX." />
+        </TextBlock>
       </StackPanel>
       
       <TextBlock Text="Navigation"

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/LoadingIndicatorSamplePage.xaml
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/LoadingIndicatorSamplePage.xaml
@@ -1,0 +1,62 @@
+<Page x:Class="MZikmund.Toolkit.Sample.LoadingIndicatorSamplePage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:local="using:MZikmund.Toolkit.Sample">
+
+  <ScrollViewer Padding="24">
+    <StackPanel Spacing="16" MaxWidth="800">
+      <TextBlock Text="ILoadingIndicator"
+                 Style="{ThemeResource TitleTextBlockStyle}" />
+
+      <TextBlock Text="ILoadingIndicator wraps a WindowShellViewModel with `using var _ = _loading.BeginLoading()` ergonomics. Concurrent scopes reference-count: IsLoading stays true until the last scope is disposed. Useful for orchestrating overlapping async operations without flickering the global spinner."
+                 TextWrapping="Wrap"
+                 Style="{ThemeResource BodyTextBlockStyle}" />
+
+      <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+              BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+              BorderThickness="1"
+              CornerRadius="8"
+              Padding="16">
+        <StackPanel Spacing="12">
+          <TextBlock Text="Live demo"
+                     Style="{ThemeResource SubtitleTextBlockStyle}" />
+
+          <TextBlock x:Name="StateText"
+                     Style="{ThemeResource BodyStrongTextBlockStyle}" />
+
+          <ProgressRing IsActive="{x:Bind ShellViewModel.IsLoading, Mode=OneWay}"
+                        HorizontalAlignment="Left" />
+
+          <TextBlock Text="{x:Bind ShellViewModel.LoadingStatusMessage, Mode=OneWay}"
+                     Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}" />
+
+          <StackPanel Orientation="Horizontal" Spacing="8">
+            <Button Content="Begin scope" Click="Begin_Click" Style="{ThemeResource AccentButtonStyle}" />
+            <Button Content="End most recent scope" Click="End_Click" />
+            <Button Content="Run nested 5s job" Click="Nested_Click" />
+          </StackPanel>
+        </StackPanel>
+      </Border>
+
+      <Border Background="{ThemeResource LayerFillColorDefaultBrush}"
+              BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+              BorderThickness="1"
+              CornerRadius="8"
+              Padding="16">
+        <StackPanel Spacing="8">
+          <TextBlock Text="Code Sample"
+                     Style="{ThemeResource SubtitleTextBlockStyle}" />
+
+          <TextBlock FontFamily="Consolas" TextWrapping="Wrap">
+            <Run>using MZikmund.Toolkit.WinUI.Services;</Run><LineBreak />
+            <LineBreak />
+            <Run>using (_loading.BeginLoading("Saving…"))</Run><LineBreak />
+            <Run>{</Run><LineBreak />
+            <Run>    await SaveAsync();</Run><LineBreak />
+            <Run>}</Run>
+          </TextBlock>
+        </StackPanel>
+      </Border>
+    </StackPanel>
+  </ScrollViewer>
+</Page>

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/LoadingIndicatorSamplePage.xaml.cs
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/LoadingIndicatorSamplePage.xaml.cs
@@ -1,0 +1,59 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using MZikmund.Toolkit.WinUI.Services;
+using MZikmund.Toolkit.WinUI.ViewModels;
+
+namespace MZikmund.Toolkit.Sample;
+
+public sealed partial class LoadingIndicatorSamplePage : Page
+{
+    private readonly Stack<IDisposable> _activeScopes = new();
+    private readonly ILoadingIndicator _indicator;
+
+    public LoadingIndicatorSamplePage()
+    {
+        ShellViewModel = new WindowShellViewModel();
+        _indicator = new LoadingIndicator(ShellViewModel);
+        this.InitializeComponent();
+        UpdateState();
+    }
+
+    public WindowShellViewModel ShellViewModel { get; }
+
+    private void Begin_Click(object sender, RoutedEventArgs e)
+    {
+        _activeScopes.Push(_indicator.BeginLoading($"Scope {_activeScopes.Count + 1}…"));
+        UpdateState();
+    }
+
+    private void End_Click(object sender, RoutedEventArgs e)
+    {
+        if (_activeScopes.Count > 0)
+        {
+            _activeScopes.Pop().Dispose();
+        }
+        UpdateState();
+    }
+
+    private async void Nested_Click(object sender, RoutedEventArgs e)
+    {
+        using var outer = _indicator.BeginLoading("Outer job…");
+        UpdateState();
+        await Task.Delay(2_000);
+
+        using (_indicator.BeginLoading("Inner job…"))
+        {
+            UpdateState();
+            await Task.Delay(2_000);
+        }
+
+        UpdateState();
+        await Task.Delay(1_000);
+        UpdateState();
+    }
+
+    private void UpdateState()
+    {
+        StateText.Text = $"IsLoading: {_indicator.IsLoading}, active scopes: {_activeScopes.Count}";
+    }
+}

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml
@@ -22,6 +22,7 @@
       <NavigationViewItem Content="XamlRoot Provider" Tag="XamlRootProvider" Icon="Page" />
       <NavigationViewItem Content="Window Shell" Tag="WindowShell" Icon="NewWindow" />
       <NavigationViewItem Content="Core Infrastructure" Tag="CoreInfrastructure" Icon="Setting" />
+      <NavigationViewItem Content="Loading Indicator" Tag="LoadingIndicator" Icon="Refresh" />
     </NavigationView.MenuItems>
 
     <Frame x:Name="ContentFrame" />

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml.cs
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml.cs
@@ -33,6 +33,7 @@ public sealed partial class Shell : Page
                 "XamlRootProvider" => typeof(XamlRootProviderSamplePage),
                 "WindowShell" => typeof(WindowShellSamplePage),
                 "CoreInfrastructure" => typeof(CoreInfrastructureSamplePage),
+                "LoadingIndicator" => typeof(LoadingIndicatorSamplePage),
                 _ => null
             };
 

--- a/src/MZikmund.Toolkit.WinUI/Services/Loading/ILoadingIndicator.cs
+++ b/src/MZikmund.Toolkit.WinUI/Services/Loading/ILoadingIndicator.cs
@@ -1,0 +1,26 @@
+namespace MZikmund.Toolkit.WinUI.Services;
+
+/// <summary>
+/// App-wide loading indicator with <c>using var _ = indicator.BeginLoading()</c>
+/// ergonomics. Reference-counts concurrent loading scopes so nested operations
+/// don't toggle <see cref="IsLoading"/> off prematurely.
+/// </summary>
+public interface ILoadingIndicator
+{
+    /// <summary>
+    /// <see langword="true"/> when at least one loading scope is active.
+    /// </summary>
+    bool IsLoading { get; }
+
+    /// <summary>
+    /// Status message shown alongside the loading indicator. Setting this updates
+    /// the underlying view-model immediately.
+    /// </summary>
+    string? StatusMessage { get; set; }
+
+    /// <summary>
+    /// Begins a loading scope. Dispose the returned <see cref="IDisposable"/> to end it.
+    /// </summary>
+    /// <param name="statusMessage">Optional status text shown for this scope.</param>
+    IDisposable BeginLoading(string? statusMessage = null);
+}

--- a/src/MZikmund.Toolkit.WinUI/Services/Loading/LoadingIndicator.cs
+++ b/src/MZikmund.Toolkit.WinUI/Services/Loading/LoadingIndicator.cs
@@ -1,0 +1,86 @@
+using MZikmund.Toolkit.WinUI.ViewModels;
+
+namespace MZikmund.Toolkit.WinUI.Services;
+
+/// <summary>
+/// Default <see cref="ILoadingIndicator"/> implementation. Wraps an
+/// <see cref="IWindowShellViewModel"/> and reference-counts <see cref="BeginLoading"/>
+/// scopes. <see cref="IWindowShellViewModel.IsLoading"/> stays <see langword="true"/>
+/// until the last outstanding scope is disposed; only then is the status message reset.
+/// </summary>
+/// <remarks>
+/// Disposing a scope twice is a no-op. The implementation is thread-safe for the
+/// concurrent-scope counting case but does not synchronize updates to the underlying
+/// view-model with UI thread requirements — callers should set <see cref="StatusMessage"/>
+/// from the UI thread.
+/// </remarks>
+public sealed class LoadingIndicator : ILoadingIndicator
+{
+    private readonly IWindowShellViewModel _shellViewModel;
+    private readonly object _lock = new();
+    private int _activeCount;
+
+    /// <summary>Initializes a new instance backed by the supplied shell view-model.</summary>
+    public LoadingIndicator(IWindowShellViewModel shellViewModel)
+    {
+        ArgumentNullException.ThrowIfNull(shellViewModel);
+        _shellViewModel = shellViewModel;
+    }
+
+    /// <inheritdoc />
+    public bool IsLoading => _shellViewModel.IsLoading;
+
+    /// <inheritdoc />
+    public string? StatusMessage
+    {
+        get => _shellViewModel.LoadingStatusMessage;
+        set => _shellViewModel.LoadingStatusMessage = value;
+    }
+
+    /// <inheritdoc />
+    public IDisposable BeginLoading(string? statusMessage = null)
+    {
+        lock (_lock)
+        {
+            _activeCount++;
+            _shellViewModel.IsLoading = true;
+            if (statusMessage is not null)
+            {
+                _shellViewModel.LoadingStatusMessage = statusMessage;
+            }
+        }
+
+        return new Scope(this);
+    }
+
+    private void EndScope()
+    {
+        lock (_lock)
+        {
+            if (_activeCount == 0)
+            {
+                return;
+            }
+
+            _activeCount--;
+            if (_activeCount == 0)
+            {
+                _shellViewModel.IsLoading = false;
+                _shellViewModel.LoadingStatusMessage = null;
+            }
+        }
+    }
+
+    private sealed class Scope : IDisposable
+    {
+        private LoadingIndicator? _owner;
+
+        public Scope(LoadingIndicator owner) => _owner = owner;
+
+        public void Dispose()
+        {
+            var owner = Interlocked.Exchange(ref _owner, null);
+            owner?.EndScope();
+        }
+    }
+}

--- a/tests/MZikmund.Toolkit.WinUI.Tests/LoadingIndicatorTests.cs
+++ b/tests/MZikmund.Toolkit.WinUI.Tests/LoadingIndicatorTests.cs
@@ -1,0 +1,106 @@
+using System.Windows.Input;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MZikmund.Toolkit.WinUI.Services;
+using MZikmund.Toolkit.WinUI.ViewModels;
+
+namespace MZikmund.Toolkit.WinUI.Tests;
+
+[TestClass]
+public class LoadingIndicatorTests
+{
+    [TestMethod]
+    public void Ctor_NullShellViewModel_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => new LoadingIndicator(null!));
+    }
+
+    [TestMethod]
+    public void BeginLoading_FlipsIsLoadingTrue_AndSetsStatus()
+    {
+        var shell = new StubShellViewModel();
+        var indicator = new LoadingIndicator(shell);
+
+        using var scope = indicator.BeginLoading("Saving…");
+
+        Assert.IsTrue(indicator.IsLoading);
+        Assert.IsTrue(shell.IsLoading);
+        Assert.AreEqual("Saving…", indicator.StatusMessage);
+    }
+
+    [TestMethod]
+    public void Dispose_LastScope_ClearsIsLoadingAndStatus()
+    {
+        var shell = new StubShellViewModel();
+        var indicator = new LoadingIndicator(shell);
+        var scope = indicator.BeginLoading("Saving…");
+
+        scope.Dispose();
+
+        Assert.IsFalse(indicator.IsLoading);
+        Assert.IsNull(indicator.StatusMessage);
+    }
+
+    [TestMethod]
+    public void NestedScopes_KeepIsLoadingTrueUntilLastDisposed()
+    {
+        var shell = new StubShellViewModel();
+        var indicator = new LoadingIndicator(shell);
+
+        var outer = indicator.BeginLoading("Outer");
+        var inner = indicator.BeginLoading("Inner");
+        Assert.IsTrue(indicator.IsLoading);
+
+        inner.Dispose();
+        Assert.IsTrue(indicator.IsLoading, "Outer scope still active.");
+
+        outer.Dispose();
+        Assert.IsFalse(indicator.IsLoading);
+    }
+
+    [TestMethod]
+    public void DisposeTwice_OnSameScope_IsNoOp()
+    {
+        var shell = new StubShellViewModel();
+        var indicator = new LoadingIndicator(shell);
+
+        var scope = indicator.BeginLoading();
+        scope.Dispose();
+        scope.Dispose();
+
+        Assert.IsFalse(indicator.IsLoading);
+    }
+
+    [TestMethod]
+    public void BeginLoading_WithoutMessage_PreservesPriorMessage()
+    {
+        var shell = new StubShellViewModel();
+        var indicator = new LoadingIndicator(shell);
+        indicator.StatusMessage = "Pre-existing";
+
+        using var scope = indicator.BeginLoading();
+
+        Assert.AreEqual("Pre-existing", indicator.StatusMessage);
+    }
+
+    [TestMethod]
+    public void StatusMessage_SetterRoutesToShellViewModel()
+    {
+        var shell = new StubShellViewModel();
+        var indicator = new LoadingIndicator(shell);
+
+        indicator.StatusMessage = "Updated";
+
+        Assert.AreEqual("Updated", shell.LoadingStatusMessage);
+    }
+
+    private sealed class StubShellViewModel : IWindowShellViewModel
+    {
+        public string Title { get; set; } = string.Empty;
+
+        public bool IsLoading { get; set; }
+
+        public string? LoadingStatusMessage { get; set; }
+
+        public ICommand GoBackCommand => throw new NotSupportedException();
+    }
+}


### PR DESCRIPTION
## Summary

Adds `ILoadingIndicator` + `LoadingIndicator` in `MZikmund.Toolkit.WinUI.Services`:

- `IDisposable BeginLoading(string? statusMessage = null)` — `using var _ = _loading.BeginLoading("Saving…")` ergonomics.
- `bool IsLoading` and `string? StatusMessage { get; set; }` exposed for binding.
- Reference-counts concurrent scopes — `IsLoading` stays `true` until the last outstanding scope is disposed; only then is the status message cleared. Disposing a scope twice is a no-op. `BeginLoading()` without a message preserves the prior message so nested scopes don't blank out the outer scope's text.
- Backed by an `IWindowShellViewModel` from #53.

Wires a gallery sample (`LoadingIndicatorSamplePage`) into Shell + HomePage with a bound ProgressRing, the live status TextBlock, and three buttons (`Begin scope`, `End most recent scope`, `Run nested 5s job`) so the reference-count semantics are visible.

Adds 7 unit tests covering null-arg, basic begin/dispose flow, nested-scope counting, double-dispose safety, the message-preservation rule, and the StatusMessage setter pass-through.

Closes #43

> **Stacked PR.** Targets `feature/issue-53-core-infrastructure` (#72) — depends on `IWindowShellViewModel` from #53. Once #72 merges, retarget to `main`.

## Test plan

- [x] `dotnet build MZikmund.Toolkit.slnx -c Debug` succeeds.
- [x] Test exe reports 45/45 passed (38 prior + 7 new).
- [ ] Manually exercise the `Loading Indicator` sample on Windows: click `Begin scope` three times — the ring spins, status reflects the most recent scope. Click `End most recent scope` twice — ring still spins (one outstanding scope). Final dispose — ring stops, message clears. Click `Run nested 5s job` — ring stays continuously on through the nested transition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)