### PR TITLE
feat: Add ITimerFactory + ITimer with Fake test double

### DIFF
--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/HomePage.xaml
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/HomePage.xaml
@@ -40,6 +40,12 @@
           <Run Text="ObservableCollection Merge:" FontWeight="SemiBold" />
           <Run Text=" MergeWith extension that synchronizes an ObservableCollection with a source list using minimal Insert/RemoveAt/Move operations." />
         </TextBlock>
+
+        <TextBlock Style="{ThemeResource BodyTextBlockStyle}">
+          <Run Text="• " FontWeight="Bold" />
+          <Run Text="Timer Factory:" FontWeight="SemiBold" />
+          <Run Text=" ITimerFactory + ITimer abstraction over DispatcherQueueTimer with a FakeTimerFactory for tests." />
+        </TextBlock>
         
         <TextBlock Style="{ThemeResource BodyTextBlockStyle}">
           <Run Text="• " FontWeight="Bold" />

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/TimerFactorySamplePage.xaml
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/TimerFactorySamplePage.xaml
@@ -1,0 +1,66 @@
+<Page x:Class="MZikmund.Toolkit.Sample.TimerFactorySamplePage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:local="using:MZikmund.Toolkit.Sample">
+
+  <ScrollViewer Padding="24">
+    <StackPanel Spacing="16" MaxWidth="800">
+      <TextBlock Text="ITimerFactory + ITimer"
+                 Style="{ThemeResource TitleTextBlockStyle}" />
+
+      <TextBlock Text="ITimer is a thin abstraction over DispatcherQueueTimer. ITimerFactory.CreateTimer hands one out, bound to the UI thread. Apps depend on the interface, the toolkit ships TimerFactory (real) and FakeTimerFactory (manual ticks for tests)."
+                 TextWrapping="Wrap"
+                 Style="{ThemeResource BodyTextBlockStyle}" />
+
+      <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+              BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+              BorderThickness="1"
+              CornerRadius="8"
+              Padding="16">
+        <StackPanel Spacing="12">
+          <TextBlock Text="Live clock"
+                     Style="{ThemeResource SubtitleTextBlockStyle}" />
+
+          <TextBlock x:Name="ClockText"
+                     FontFamily="Consolas"
+                     FontSize="36"
+                     Text="--:--:--" />
+
+          <StackPanel Orientation="Horizontal" Spacing="8">
+            <Button x:Name="StartStopButton"
+                    Content="Start"
+                    Click="StartStop_Click"
+                    Style="{ThemeResource AccentButtonStyle}" />
+          </StackPanel>
+
+          <TextBlock Text="Interval = 1s. Toggling the button calls timer.Start() / timer.Stop() through ITimer."
+                     TextWrapping="Wrap"
+                     Style="{ThemeResource BodyTextBlockStyle}" />
+        </StackPanel>
+      </Border>
+
+      <Border Background="{ThemeResource LayerFillColorDefaultBrush}"
+              BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+              BorderThickness="1"
+              CornerRadius="8"
+              Padding="16">
+        <StackPanel Spacing="8">
+          <TextBlock Text="Code Sample"
+                     Style="{ThemeResource SubtitleTextBlockStyle}" />
+
+          <TextBlock FontFamily="Consolas" TextWrapping="Wrap">
+            <Run>using MZikmund.Toolkit.WinUI.Services;</Run><LineBreak />
+            <LineBreak />
+            <Run>// Production wiring</Run><LineBreak />
+            <Run>services.AddSingleton&lt;ITimerFactory, TimerFactory&gt;();</Run><LineBreak />
+            <LineBreak />
+            <Run>// Tests</Run><LineBreak />
+            <Run>var fakeFactory = new FakeTimerFactory();</Run><LineBreak />
+            <Run>var sut = new MyViewModel(fakeFactory);</Run><LineBreak />
+            <Run>fakeFactory.Timers[0].RaiseTick(count: 5);</Run>
+          </TextBlock>
+        </StackPanel>
+      </Border>
+    </StackPanel>
+  </ScrollViewer>
+</Page>

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/TimerFactorySamplePage.xaml.cs
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/TimerFactorySamplePage.xaml.cs
@@ -1,0 +1,38 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using MZikmund.Toolkit.WinUI.Services;
+
+namespace MZikmund.Toolkit.Sample;
+
+public sealed partial class TimerFactorySamplePage : Page
+{
+    private readonly MZikmund.Toolkit.WinUI.Services.ITimerFactory _factory;
+    private readonly MZikmund.Toolkit.WinUI.Services.ITimer _timer;
+
+    public TimerFactorySamplePage()
+    {
+        this.InitializeComponent();
+        _factory = new TimerFactory();
+        _timer = _factory.CreateTimer(TimeSpan.FromSeconds(1));
+        _timer.Tick += OnTick;
+        UpdateClock();
+    }
+
+    private void StartStop_Click(object sender, RoutedEventArgs e)
+    {
+        if (_timer.IsRunning)
+        {
+            _timer.Stop();
+            StartStopButton.Content = "Start";
+        }
+        else
+        {
+            _timer.Start();
+            StartStopButton.Content = "Stop";
+        }
+    }
+
+    private void OnTick(object? sender, EventArgs e) => UpdateClock();
+
+    private void UpdateClock() => ClockText.Text = DateTimeOffset.Now.ToString("HH:mm:ss");
+}

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml
@@ -18,6 +18,8 @@
       <NavigationViewItemHeader Content="Extensions" />
       <NavigationViewItem Content="Package Version" Tag="PackageVersion" Icon="Document" />
       <NavigationViewItem Content="ObservableCollection Merge" Tag="ObservableCollectionMerge" Icon="List" />
+      <NavigationViewItemHeader Content="Timing" />
+      <NavigationViewItem Content="Timer Factory" Tag="TimerFactory" Icon="Clock" />
       <NavigationViewItemHeader Content="Infrastructure" />
       <NavigationViewItem Content="XamlRoot Provider" Tag="XamlRootProvider" Icon="Page" />
     </NavigationView.MenuItems>

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml.cs
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml.cs
@@ -30,6 +30,7 @@ public sealed partial class Shell : Page
                 "DialogCoordinator" => typeof(DialogCoordinatorSamplePage),
                 "PackageVersion" => typeof(PackageVersionSamplePage),
                 "ObservableCollectionMerge" => typeof(ObservableCollectionMergeSamplePage),
+                "TimerFactory" => typeof(TimerFactorySamplePage),
                 "XamlRootProvider" => typeof(XamlRootProviderSamplePage),
                 _ => null
             };

--- a/src/MZikmund.Toolkit.WinUI/Services/Timer/FakeTimerFactory.cs
+++ b/src/MZikmund.Toolkit.WinUI/Services/Timer/FakeTimerFactory.cs
@@ -1,0 +1,69 @@
+namespace MZikmund.Toolkit.WinUI.Services;
+
+/// <summary>
+/// Test-only <see cref="ITimerFactory"/> that returns <see cref="FakeTimer"/> instances
+/// whose ticks are driven manually. Use in unit tests to assert behavior under a
+/// known number of ticks without flaky time-based waits.
+/// </summary>
+public sealed class FakeTimerFactory : ITimerFactory
+{
+    private readonly List<FakeTimer> _timers = new();
+
+    /// <summary>All timers created so far, in creation order.</summary>
+    public IReadOnlyList<FakeTimer> Timers => _timers;
+
+    /// <inheritdoc />
+    public ITimer CreateTimer(TimeSpan interval)
+    {
+        var timer = new FakeTimer { Interval = interval };
+        _timers.Add(timer);
+        return timer;
+    }
+}
+
+/// <summary>
+/// Test-only <see cref="ITimer"/> implementation. Tracks <see cref="IsRunning"/>
+/// from <see cref="Start"/> / <see cref="Stop"/> calls and lets tests fire ticks
+/// manually with <see cref="RaiseTick"/>.
+/// </summary>
+public sealed class FakeTimer : ITimer
+{
+    /// <inheritdoc />
+    public TimeSpan Interval { get; set; }
+
+    /// <inheritdoc />
+    public bool IsRunning { get; private set; }
+
+    /// <inheritdoc />
+    public event EventHandler? Tick;
+
+    /// <inheritdoc />
+    public void Start() => IsRunning = true;
+
+    /// <inheritdoc />
+    public void Stop() => IsRunning = false;
+
+    /// <summary>
+    /// Manually raises the <see cref="Tick"/> event. No-ops while the timer is stopped.
+    /// </summary>
+    public void RaiseTick()
+    {
+        if (!IsRunning)
+        {
+            return;
+        }
+
+        Tick?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>
+    /// Convenience for raising <see cref="Tick"/> multiple times in a row.
+    /// </summary>
+    public void RaiseTick(int count)
+    {
+        for (var i = 0; i < count; i++)
+        {
+            RaiseTick();
+        }
+    }
+}

--- a/src/MZikmund.Toolkit.WinUI/Services/Timer/ITimer.cs
+++ b/src/MZikmund.Toolkit.WinUI/Services/Timer/ITimer.cs
@@ -1,0 +1,24 @@
+namespace MZikmund.Toolkit.WinUI.Services;
+
+/// <summary>
+/// Thin abstraction over a UI-thread timer (typically <c>DispatcherQueueTimer</c>).
+/// Lets view-models and services depend on a tickable clock without referencing the
+/// platform type directly, which makes them testable with a fake.
+/// </summary>
+public interface ITimer
+{
+    /// <summary>Tick interval. Setting this while the timer is running takes effect on the next tick.</summary>
+    TimeSpan Interval { get; set; }
+
+    /// <summary><see langword="true"/> while the timer is started.</summary>
+    bool IsRunning { get; }
+
+    /// <summary>Raised on each tick, on the timer's owning UI thread.</summary>
+    event EventHandler? Tick;
+
+    /// <summary>Starts ticking. No-op when already running.</summary>
+    void Start();
+
+    /// <summary>Stops ticking. No-op when already stopped.</summary>
+    void Stop();
+}

--- a/src/MZikmund.Toolkit.WinUI/Services/Timer/ITimerFactory.cs
+++ b/src/MZikmund.Toolkit.WinUI/Services/Timer/ITimerFactory.cs
@@ -1,0 +1,14 @@
+namespace MZikmund.Toolkit.WinUI.Services;
+
+/// <summary>
+/// Creates <see cref="ITimer"/> instances on the owning UI thread. The default
+/// <see cref="TimerFactory"/> delegates to <c>DispatcherQueue.CreateTimer</c>;
+/// tests use <see cref="FakeTimerFactory"/> to advance time deterministically.
+/// </summary>
+public interface ITimerFactory
+{
+    /// <summary>
+    /// Creates a stopped timer with the given <paramref name="interval"/>.
+    /// </summary>
+    ITimer CreateTimer(TimeSpan interval);
+}

--- a/src/MZikmund.Toolkit.WinUI/Services/Timer/TimerFactory.cs
+++ b/src/MZikmund.Toolkit.WinUI/Services/Timer/TimerFactory.cs
@@ -1,0 +1,64 @@
+using Microsoft.UI.Dispatching;
+
+namespace MZikmund.Toolkit.WinUI.Services;
+
+/// <summary>
+/// Default <see cref="ITimerFactory"/> that produces <see cref="ITimer"/> instances
+/// backed by <see cref="DispatcherQueueTimer"/>.
+/// </summary>
+public sealed class TimerFactory : ITimerFactory
+{
+    private readonly DispatcherQueue _dispatcherQueue;
+
+    /// <summary>
+    /// Initializes a new instance bound to the supplied <paramref name="dispatcherQueue"/>.
+    /// </summary>
+    public TimerFactory(DispatcherQueue dispatcherQueue)
+    {
+        ArgumentNullException.ThrowIfNull(dispatcherQueue);
+        _dispatcherQueue = dispatcherQueue;
+    }
+
+    /// <summary>
+    /// Initializes a new instance using the dispatcher queue of the calling thread.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">No <see cref="DispatcherQueue"/> is associated with the calling thread.</exception>
+    public TimerFactory()
+        : this(DispatcherQueue.GetForCurrentThread()
+            ?? throw new InvalidOperationException("No DispatcherQueue is associated with the calling thread. Construct TimerFactory on a UI thread, or pass a DispatcherQueue explicitly."))
+    {
+    }
+
+    /// <inheritdoc />
+    public ITimer CreateTimer(TimeSpan interval)
+    {
+        var inner = _dispatcherQueue.CreateTimer();
+        inner.Interval = interval;
+        return new DispatcherQueueTimerAdapter(inner);
+    }
+
+    private sealed class DispatcherQueueTimerAdapter : ITimer
+    {
+        private readonly DispatcherQueueTimer _inner;
+
+        public DispatcherQueueTimerAdapter(DispatcherQueueTimer inner)
+        {
+            _inner = inner;
+            _inner.Tick += (s, e) => Tick?.Invoke(this, EventArgs.Empty);
+        }
+
+        public TimeSpan Interval
+        {
+            get => _inner.Interval;
+            set => _inner.Interval = value;
+        }
+
+        public bool IsRunning => _inner.IsRunning;
+
+        public event EventHandler? Tick;
+
+        public void Start() => _inner.Start();
+
+        public void Stop() => _inner.Stop();
+    }
+}

--- a/tests/MZikmund.Toolkit.WinUI.Tests/TimerFactoryTests.cs
+++ b/tests/MZikmund.Toolkit.WinUI.Tests/TimerFactoryTests.cs
@@ -1,0 +1,91 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MZikmund.Toolkit.WinUI.Services;
+
+namespace MZikmund.Toolkit.WinUI.Tests;
+
+[TestClass]
+public class FakeTimerFactoryTests
+{
+    [TestMethod]
+    public void CreateTimer_ReturnsStoppedTimer_WithRequestedInterval()
+    {
+        var factory = new FakeTimerFactory();
+
+        var timer = factory.CreateTimer(TimeSpan.FromSeconds(5));
+
+        Assert.IsFalse(timer.IsRunning);
+        Assert.AreEqual(TimeSpan.FromSeconds(5), timer.Interval);
+    }
+
+    [TestMethod]
+    public void CreateTimer_TracksAllCreatedTimers()
+    {
+        var factory = new FakeTimerFactory();
+
+        var a = factory.CreateTimer(TimeSpan.FromSeconds(1));
+        var b = factory.CreateTimer(TimeSpan.FromSeconds(2));
+
+        Assert.AreEqual(2, factory.Timers.Count);
+        Assert.AreSame(a, factory.Timers[0]);
+        Assert.AreSame(b, factory.Timers[1]);
+    }
+
+    [TestMethod]
+    public void Start_FlipsIsRunning()
+    {
+        var timer = (FakeTimer)new FakeTimerFactory().CreateTimer(TimeSpan.FromSeconds(1));
+
+        timer.Start();
+
+        Assert.IsTrue(timer.IsRunning);
+    }
+
+    [TestMethod]
+    public void Stop_FlipsIsRunningOff()
+    {
+        var timer = (FakeTimer)new FakeTimerFactory().CreateTimer(TimeSpan.FromSeconds(1));
+        timer.Start();
+
+        timer.Stop();
+
+        Assert.IsFalse(timer.IsRunning);
+    }
+
+    [TestMethod]
+    public void RaiseTick_WhenRunning_FiresTickEvent()
+    {
+        var timer = (FakeTimer)new FakeTimerFactory().CreateTimer(TimeSpan.FromSeconds(1));
+        var ticks = 0;
+        timer.Tick += (_, _) => ticks++;
+        timer.Start();
+
+        timer.RaiseTick();
+
+        Assert.AreEqual(1, ticks);
+    }
+
+    [TestMethod]
+    public void RaiseTick_WhenStopped_DoesNotFire()
+    {
+        var timer = (FakeTimer)new FakeTimerFactory().CreateTimer(TimeSpan.FromSeconds(1));
+        var ticks = 0;
+        timer.Tick += (_, _) => ticks++;
+
+        timer.RaiseTick();
+
+        Assert.AreEqual(0, ticks);
+    }
+
+    [TestMethod]
+    public void RaiseTick_Count_FiresMultipleTimes()
+    {
+        var timer = (FakeTimer)new FakeTimerFactory().CreateTimer(TimeSpan.FromSeconds(1));
+        var ticks = 0;
+        timer.Tick += (_, _) => ticks++;
+        timer.Start();
+
+        timer.RaiseTick(count: 5);
+
+        Assert.AreEqual(5, ticks);
+    }
+}


### PR DESCRIPTION
## Summary

Adds the UI-thread timer abstraction described in #35 under `MZikmund.Toolkit.WinUI.Services`:

- `ITimer` — thin abstraction over a UI-thread timer (`Interval`, `IsRunning`, `Tick`, `Start`, `Stop`).
- `ITimerFactory` — `CreateTimer(TimeSpan)` returns an `ITimer` bound to the UI thread.
- `TimerFactory` — production impl that wraps `DispatcherQueue.CreateTimer`. Parameterless constructor picks up `DispatcherQueue.GetForCurrentThread()` (throws with a clear message off the UI thread).
- `FakeTimerFactory` + `FakeTimer` — test doubles. `FakeTimer.RaiseTick()` and `RaiseTick(int count)` fire the `Tick` event manually; ticks are ignored while the timer is stopped so tests can assert state-machine semantics. `FakeTimerFactory.Timers` exposes the list of timers created so far for assertion.

Wires a gallery sample (`TimerFactorySamplePage`) into Shell + HomePage with a 1-second clock TextBlock and a Start/Stop button bound to `ITimer`.

Adds 7 unit tests covering interval propagation, factory creation tracking, Start/Stop transitions, the run-vs-stop tick gating, and `RaiseTick(count)`.

Closes #35

> Stacked on top of #56 (the `MergeWith` PR). Rebase on `main` once #56 merges.

## Test plan

- [x] `dotnet build MZikmund.Toolkit.slnx -c Debug` succeeds.
- [x] Test exe reports 21/21 passed (14 prior + 7 new).
- [ ] Manually exercise the `Timer Factory` sample on Windows: click `Start`, verify the clock TextBlock updates once per second; click `Stop` and confirm it freezes; click again to resume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)