### PR TITLE
feat: Add IDeepLinkService for pending-navigation queueing

### DIFF
--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/DeepLinkSamplePage.xaml
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/DeepLinkSamplePage.xaml
@@ -1,0 +1,73 @@
+<Page x:Class="MZikmund.Toolkit.Sample.DeepLinkSamplePage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:local="using:MZikmund.Toolkit.Sample">
+
+  <ScrollViewer Padding="24">
+    <StackPanel Spacing="16" MaxWidth="800">
+      <TextBlock Text="IDeepLinkService"
+                 Style="{ThemeResource TitleTextBlockStyle}" />
+
+      <TextBlock Text="IDeepLinkService captures deep-link / pending-navigation requests that arrive before the shell is ready, and replays them once init completes. Apps Enqueue() in their app-launch handler and Replay() once the shell is fully online; consumers subscribe to RequestReceived to navigate."
+                 TextWrapping="Wrap"
+                 Style="{ThemeResource BodyTextBlockStyle}" />
+
+      <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+              BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+              BorderThickness="1"
+              CornerRadius="8"
+              Padding="16">
+        <StackPanel Spacing="12">
+          <TextBlock Text="Live demo"
+                     Style="{ThemeResource SubtitleTextBlockStyle}" />
+
+          <TextBox x:Name="UriInput"
+                   Header="URI"
+                   PlaceholderText="myapp://reminder/42"
+                   Text="myapp://reminder/42" />
+
+          <StackPanel Orientation="Horizontal" Spacing="8">
+            <Button Content="Enqueue" Click="Enqueue_Click" Style="{ThemeResource AccentButtonStyle}" />
+            <Button Content="Replay" Click="Replay_Click" />
+            <Button Content="Async dequeue (5s timeout)" Click="DequeueAsync_Click" />
+          </StackPanel>
+
+          <TextBlock Text="RequestReceived log:"
+                     Style="{ThemeResource BodyStrongTextBlockStyle}" />
+          <Border BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                  BorderThickness="1"
+                  CornerRadius="4"
+                  MinHeight="120"
+                  Padding="8">
+            <TextBlock x:Name="LogText"
+                       FontFamily="Consolas"
+                       TextWrapping="Wrap"
+                       Text="(empty)" />
+          </Border>
+        </StackPanel>
+      </Border>
+
+      <Border Background="{ThemeResource LayerFillColorDefaultBrush}"
+              BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+              BorderThickness="1"
+              CornerRadius="8"
+              Padding="16">
+        <StackPanel Spacing="8">
+          <TextBlock Text="Code Sample"
+                     Style="{ThemeResource SubtitleTextBlockStyle}" />
+
+          <TextBlock FontFamily="Consolas" TextWrapping="Wrap">
+            <Run>using MZikmund.Toolkit.WinUI.Services;</Run><LineBreak />
+            <LineBreak />
+            <Run>// In OnLaunched / activation handler</Run><LineBreak />
+            <Run>_deepLink.Enqueue(new DeepLinkRequest(activatingUri));</Run><LineBreak />
+            <LineBreak />
+            <Run>// In shell after init</Run><LineBreak />
+            <Run>_deepLink.RequestReceived += (s, req) =&gt; NavigateFor(req);</Run><LineBreak />
+            <Run>_deepLink.Replay();</Run>
+          </TextBlock>
+        </StackPanel>
+      </Border>
+    </StackPanel>
+  </ScrollViewer>
+</Page>

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/DeepLinkSamplePage.xaml.cs
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/DeepLinkSamplePage.xaml.cs
@@ -1,0 +1,55 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using MZikmund.Toolkit.WinUI.Services;
+
+namespace MZikmund.Toolkit.Sample;
+
+public sealed partial class DeepLinkSamplePage : Page
+{
+    private readonly IDeepLinkService _service = new DeepLinkService();
+    private readonly List<string> _log = new();
+
+    public DeepLinkSamplePage()
+    {
+        this.InitializeComponent();
+        _service.RequestReceived += (sender, request) =>
+        {
+            _log.Add($"[{DateTimeOffset.Now:HH:mm:ss}] RequestReceived: {request.Uri}");
+            UpdateLog();
+        };
+    }
+
+    private void Enqueue_Click(object sender, RoutedEventArgs e)
+    {
+        if (!Uri.TryCreate((UriInput.Text ?? string.Empty).Trim(), UriKind.RelativeOrAbsolute, out var uri))
+        {
+            _log.Add("[error] Not a valid URI.");
+            UpdateLog();
+            return;
+        }
+
+        _service.Enqueue(new DeepLinkRequest(uri));
+        _log.Add($"[{DateTimeOffset.Now:HH:mm:ss}] Enqueued: {uri}");
+        UpdateLog();
+    }
+
+    private void Replay_Click(object sender, RoutedEventArgs e)
+    {
+        var replayed = _service.Replay();
+        _log.Add($"[{DateTimeOffset.Now:HH:mm:ss}] Replay drained {replayed} request(s).");
+        UpdateLog();
+    }
+
+    private async void DequeueAsync_Click(object sender, RoutedEventArgs e)
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var request = await _service.TryDequeueAsync(cts.Token);
+        _log.Add(request is null
+            ? $"[{DateTimeOffset.Now:HH:mm:ss}] Async dequeue timed out / cancelled."
+            : $"[{DateTimeOffset.Now:HH:mm:ss}] Async dequeue: {request.Uri}");
+        UpdateLog();
+    }
+
+    private void UpdateLog() =>
+        LogText.Text = _log.Count == 0 ? "(empty)" : string.Join("\n", _log);
+}

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/HomePage.xaml
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/HomePage.xaml
@@ -40,6 +40,12 @@
           <Run Text="ObservableCollection Merge:" FontWeight="SemiBold" />
           <Run Text=" MergeWith extension that synchronizes an ObservableCollection with a source list using minimal Insert/RemoveAt/Move operations." />
         </TextBlock>
+
+        <TextBlock Style="{ThemeResource BodyTextBlockStyle}">
+          <Run Text="• " FontWeight="Bold" />
+          <Run Text="Deep Link:" FontWeight="SemiBold" />
+          <Run Text=" IDeepLinkService that queues activation URIs before the shell is ready and replays them after init." />
+        </TextBlock>
         
         <TextBlock Style="{ThemeResource BodyTextBlockStyle}">
           <Run Text="• " FontWeight="Bold" />

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml
@@ -18,6 +18,8 @@
       <NavigationViewItemHeader Content="Extensions" />
       <NavigationViewItem Content="Package Version" Tag="PackageVersion" Icon="Document" />
       <NavigationViewItem Content="ObservableCollection Merge" Tag="ObservableCollectionMerge" Icon="List" />
+      <NavigationViewItemHeader Content="Activation" />
+      <NavigationViewItem Content="Deep Link" Tag="DeepLink" Icon="Link" />
       <NavigationViewItemHeader Content="Infrastructure" />
       <NavigationViewItem Content="XamlRoot Provider" Tag="XamlRootProvider" Icon="Page" />
     </NavigationView.MenuItems>

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml.cs
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml.cs
@@ -30,6 +30,7 @@ public sealed partial class Shell : Page
                 "DialogCoordinator" => typeof(DialogCoordinatorSamplePage),
                 "PackageVersion" => typeof(PackageVersionSamplePage),
                 "ObservableCollectionMerge" => typeof(ObservableCollectionMergeSamplePage),
+                "DeepLink" => typeof(DeepLinkSamplePage),
                 "XamlRootProvider" => typeof(XamlRootProviderSamplePage),
                 _ => null
             };

--- a/src/MZikmund.Toolkit.WinUI/Services/DeepLink/DeepLinkRequest.cs
+++ b/src/MZikmund.Toolkit.WinUI/Services/DeepLink/DeepLinkRequest.cs
@@ -1,0 +1,12 @@
+namespace MZikmund.Toolkit.WinUI.Services;
+
+/// <summary>
+/// A captured deep-link / pending-navigation request: the activating <see cref="Uri"/>
+/// plus optional structured parameters extracted from it.
+/// </summary>
+/// <param name="Uri">The activating URI (e.g. <c>myapp://reminder/42</c>).</param>
+/// <param name="Parameters">
+/// Optional already-parsed parameters. The toolkit doesn't prescribe how callers parse
+/// the URI — apps that already split the URI into a key/value bag can pass it here.
+/// </param>
+public sealed record DeepLinkRequest(Uri Uri, IReadOnlyDictionary<string, string>? Parameters = null);

--- a/src/MZikmund.Toolkit.WinUI/Services/DeepLink/DeepLinkService.cs
+++ b/src/MZikmund.Toolkit.WinUI/Services/DeepLink/DeepLinkService.cs
@@ -1,0 +1,53 @@
+using System.Threading.Channels;
+
+namespace MZikmund.Toolkit.WinUI.Services;
+
+/// <summary>
+/// Default <see cref="IDeepLinkService"/>. Backed by an unbounded
+/// <see cref="Channel{T}"/> so concurrent <see cref="Enqueue"/> /
+/// <see cref="TryDequeueAsync"/> calls are safe without explicit locking.
+/// </summary>
+public sealed class DeepLinkService : IDeepLinkService
+{
+    private readonly Channel<DeepLinkRequest> _channel = Channel.CreateUnbounded<DeepLinkRequest>(
+        new UnboundedChannelOptions
+        {
+            SingleReader = false,
+            SingleWriter = false,
+        });
+
+    /// <inheritdoc />
+    public event EventHandler<DeepLinkRequest>? RequestReceived;
+
+    /// <inheritdoc />
+    public void Enqueue(DeepLinkRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        _channel.Writer.TryWrite(request);
+    }
+
+    /// <inheritdoc />
+    public async Task<DeepLinkRequest?> TryDequeueAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            return await _channel.Reader.ReadAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            return null;
+        }
+    }
+
+    /// <inheritdoc />
+    public int Replay()
+    {
+        var count = 0;
+        while (_channel.Reader.TryRead(out var request))
+        {
+            RequestReceived?.Invoke(this, request);
+            count++;
+        }
+        return count;
+    }
+}

--- a/src/MZikmund.Toolkit.WinUI/Services/DeepLink/IDeepLinkService.cs
+++ b/src/MZikmund.Toolkit.WinUI/Services/DeepLink/IDeepLinkService.cs
@@ -1,0 +1,28 @@
+namespace MZikmund.Toolkit.WinUI.Services;
+
+/// <summary>
+/// Captures deep-link / pending-navigation requests when the shell isn't ready
+/// yet, then replays them after init. Pairs with notification taps and tile
+/// activation: the OS hands the app a URI before any UI is alive, and the shell
+/// drains the queue once it's ready to navigate.
+/// </summary>
+public interface IDeepLinkService
+{
+    /// <summary>Raised by <see cref="Replay"/> for each queued request, in arrival order.</summary>
+    event EventHandler<DeepLinkRequest>? RequestReceived;
+
+    /// <summary>Adds a request to the queue. Safe to call from any thread.</summary>
+    void Enqueue(DeepLinkRequest request);
+
+    /// <summary>
+    /// Awaits the next queued request. Returns <see langword="null"/> if the wait is cancelled.
+    /// </summary>
+    Task<DeepLinkRequest?> TryDequeueAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Drains all currently queued requests synchronously, raising
+    /// <see cref="RequestReceived"/> for each in order.
+    /// </summary>
+    /// <returns>The number of requests replayed.</returns>
+    int Replay();
+}

--- a/tests/MZikmund.Toolkit.WinUI.Tests/DeepLinkServiceTests.cs
+++ b/tests/MZikmund.Toolkit.WinUI.Tests/DeepLinkServiceTests.cs
@@ -1,0 +1,127 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MZikmund.Toolkit.WinUI.Services;
+
+namespace MZikmund.Toolkit.WinUI.Tests;
+
+[TestClass]
+public class DeepLinkServiceTests
+{
+    [TestMethod]
+    public void Enqueue_NullRequest_Throws()
+    {
+        var service = new DeepLinkService();
+
+        Assert.Throws<ArgumentNullException>(() => service.Enqueue(null!));
+    }
+
+    [TestMethod]
+    public void Replay_FiresRequestReceived_ForEachQueuedItem_InOrder()
+    {
+        var service = new DeepLinkService();
+        var captured = new List<Uri>();
+        service.RequestReceived += (_, request) => captured.Add(request.Uri);
+
+        service.Enqueue(new DeepLinkRequest(new Uri("myapp://a")));
+        service.Enqueue(new DeepLinkRequest(new Uri("myapp://b")));
+        service.Enqueue(new DeepLinkRequest(new Uri("myapp://c")));
+
+        var replayed = service.Replay();
+
+        Assert.AreEqual(3, replayed);
+        CollectionAssert.AreEqual(
+            new[] { new Uri("myapp://a"), new Uri("myapp://b"), new Uri("myapp://c") },
+            captured);
+    }
+
+    [TestMethod]
+    public void Replay_OnEmptyQueue_ReturnsZeroAndDoesNotFire()
+    {
+        var service = new DeepLinkService();
+        var fired = 0;
+        service.RequestReceived += (_, _) => fired++;
+
+        var replayed = service.Replay();
+
+        Assert.AreEqual(0, replayed);
+        Assert.AreEqual(0, fired);
+    }
+
+    [TestMethod]
+    public void Replay_DrainsQueue_SoSecondReplayIsZero()
+    {
+        var service = new DeepLinkService();
+        service.Enqueue(new DeepLinkRequest(new Uri("myapp://a")));
+        service.Replay();
+
+        Assert.AreEqual(0, service.Replay());
+    }
+
+    [TestMethod]
+    public async Task TryDequeueAsync_ReturnsEnqueuedItem()
+    {
+        var service = new DeepLinkService();
+        var request = new DeepLinkRequest(new Uri("myapp://reminder/42"));
+        service.Enqueue(request);
+
+        var dequeued = await service.TryDequeueAsync();
+
+        Assert.AreSame(request, dequeued);
+    }
+
+    [TestMethod]
+    public async Task TryDequeueAsync_PreservesArrivalOrder()
+    {
+        var service = new DeepLinkService();
+        service.Enqueue(new DeepLinkRequest(new Uri("myapp://1")));
+        service.Enqueue(new DeepLinkRequest(new Uri("myapp://2")));
+        service.Enqueue(new DeepLinkRequest(new Uri("myapp://3")));
+
+        var first = await service.TryDequeueAsync();
+        var second = await service.TryDequeueAsync();
+        var third = await service.TryDequeueAsync();
+
+        Assert.AreEqual(new Uri("myapp://1"), first?.Uri);
+        Assert.AreEqual(new Uri("myapp://2"), second?.Uri);
+        Assert.AreEqual(new Uri("myapp://3"), third?.Uri);
+    }
+
+    [TestMethod]
+    public async Task TryDequeueAsync_Cancelled_ReturnsNull()
+    {
+        var service = new DeepLinkService();
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var result = await service.TryDequeueAsync(cts.Token);
+
+        Assert.IsNull(result);
+    }
+
+    [TestMethod]
+    public async Task TryDequeueAsync_DoesNotFireRequestReceivedEvent()
+    {
+        // RequestReceived is the Replay() channel; async dequeue is independent.
+        var service = new DeepLinkService();
+        var fired = 0;
+        service.RequestReceived += (_, _) => fired++;
+        service.Enqueue(new DeepLinkRequest(new Uri("myapp://1")));
+
+        await service.TryDequeueAsync();
+
+        Assert.AreEqual(0, fired);
+    }
+
+    [TestMethod]
+    public void Replay_AfterAsyncDequeue_OnlyReplaysRemaining()
+    {
+        var service = new DeepLinkService();
+        service.Enqueue(new DeepLinkRequest(new Uri("myapp://1")));
+        service.Enqueue(new DeepLinkRequest(new Uri("myapp://2")));
+
+        // Synchronously consume one through the async channel and then replay.
+        var t = service.TryDequeueAsync();
+        Assert.IsTrue(t.IsCompletedSuccessfully);
+
+        Assert.AreEqual(1, service.Replay());
+    }
+}


### PR DESCRIPTION
## Summary

Adds the deep-link / pending-navigation service in `MZikmund.Toolkit.WinUI.Services`:

- `DeepLinkRequest` record — `Uri` plus an optional `IReadOnlyDictionary<string, string>?` parameters bag.
- `IDeepLinkService` — `Enqueue`, `TryDequeueAsync`, `Replay`, and a `RequestReceived` event that `Replay` raises for each queued item in arrival order. `TryDequeueAsync` returns `null` on cancellation.
- `DeepLinkService` — backed by an unbounded `Channel<T>` so concurrent `Enqueue` / `TryDequeueAsync` calls are safe without explicit locking. `Replay()` drains the queue synchronously and returns the number of replayed requests.

Wires a gallery sample (`DeepLinkSamplePage`) into Shell + HomePage with `Enqueue` / `Replay` / async-dequeue buttons and a live event log.

Adds 9 unit tests covering null-arg, replay ordering, replay-on-empty, the queue draining after replay, async dequeue, async order preservation, async cancellation returning null, async dequeue not raising RequestReceived, and the interaction between async dequeue + Replay.

Closes #26

> Stacked on top of #56 (the `MergeWith` PR). Rebase on `main` once #56 merges.

## Test plan

- [x] `dotnet build MZikmund.Toolkit.slnx -c Debug` succeeds.
- [x] Test exe reports 23/23 passed (14 prior + 9 new).
- [ ] Manually exercise the `Deep Link` sample on Windows: enqueue 2-3 URIs, click `Replay` and confirm the log shows three RequestReceived entries; click `Async dequeue` with an empty queue, confirm the 5s timeout fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)