### PR TITLE
feat: Add IMailService for mailto: launch

### DIFF
--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/HomePage.xaml
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/HomePage.xaml
@@ -46,6 +46,12 @@
           <Run Text="Platform Services:" FontWeight="SemiBold" />
           <Run Text=" ILauncherService (URI launcher), IDisplayRequestManager (keep-screen-on), IShareService (text/URL share)." />
         </TextBlock>
+
+        <TextBlock Style="{ThemeResource BodyTextBlockStyle}">
+          <Run Text="• " FontWeight="Bold" />
+          <Run Text="Mail Service:" FontWeight="SemiBold" />
+          <Run Text=" IMailService.ComposeMailAsync builds a mailto: URI and hands it to ILauncherService." />
+        </TextBlock>
         
         <TextBlock Style="{ThemeResource BodyTextBlockStyle}">
           <Run Text="• " FontWeight="Bold" />

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/MailServiceSamplePage.xaml
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/MailServiceSamplePage.xaml
@@ -1,0 +1,66 @@
+<Page x:Class="MZikmund.Toolkit.Sample.MailServiceSamplePage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:local="using:MZikmund.Toolkit.Sample">
+
+  <ScrollViewer Padding="24">
+    <StackPanel Spacing="16" MaxWidth="800">
+      <TextBlock Text="IMailService"
+                 Style="{ThemeResource TitleTextBlockStyle}" />
+
+      <TextBlock Text="IMailService.ComposeMailAsync builds a mailto: URI and hands it to ILauncherService, which opens the user's default mail client pre-populated with the recipient, subject, and body."
+                 TextWrapping="Wrap"
+                 Style="{ThemeResource BodyTextBlockStyle}" />
+
+      <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+              BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+              BorderThickness="1"
+              CornerRadius="8"
+              Padding="16">
+        <StackPanel Spacing="12">
+          <TextBlock Text="Compose"
+                     Style="{ThemeResource SubtitleTextBlockStyle}" />
+
+          <TextBox x:Name="ToInput" Header="To" Text="support@example.com" />
+          <TextBox x:Name="SubjectInput" Header="Subject" Text="Hello from the toolkit" />
+          <TextBox x:Name="BodyInput"
+                   Header="Body"
+                   AcceptsReturn="True"
+                   Height="80"
+                   Text="This message was composed via IMailService." />
+
+          <Button Content="Open mail client" Click="Compose_Click" Style="{ThemeResource AccentButtonStyle}" />
+
+          <TextBlock x:Name="UriPreviewText"
+                     FontFamily="Consolas"
+                     TextWrapping="Wrap"
+                     Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}" />
+        </StackPanel>
+      </Border>
+
+      <Border Background="{ThemeResource LayerFillColorDefaultBrush}"
+              BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+              BorderThickness="1"
+              CornerRadius="8"
+              Padding="16">
+        <StackPanel Spacing="8">
+          <TextBlock Text="Code Sample"
+                     Style="{ThemeResource SubtitleTextBlockStyle}" />
+
+          <TextBlock FontFamily="Consolas" TextWrapping="Wrap">
+            <Run>using MZikmund.Toolkit.WinUI.Services;</Run><LineBreak />
+            <LineBreak />
+            <Run>// DI registration</Run><LineBreak />
+            <Run>services.AddSingleton&lt;ILauncherService, LauncherService&gt;();</Run><LineBreak />
+            <Run>services.AddSingleton&lt;IMailService, MailService&gt;();</Run><LineBreak />
+            <LineBreak />
+            <Run>await mail.ComposeMailAsync(</Run><LineBreak />
+            <Run>    addressTo: "support@example.com",</Run><LineBreak />
+            <Run>    subject: "Help",</Run><LineBreak />
+            <Run>    body: "I have a question…");</Run>
+          </TextBlock>
+        </StackPanel>
+      </Border>
+    </StackPanel>
+  </ScrollViewer>
+</Page>

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/MailServiceSamplePage.xaml.cs
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/MailServiceSamplePage.xaml.cs
@@ -1,0 +1,37 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using MZikmund.Toolkit.WinUI.Services;
+
+namespace MZikmund.Toolkit.Sample;
+
+public sealed partial class MailServiceSamplePage : Page
+{
+    private readonly IMailService _mail = new MailService();
+
+    public MailServiceSamplePage()
+    {
+        this.InitializeComponent();
+    }
+
+    private async void Compose_Click(object sender, RoutedEventArgs e)
+    {
+        var addressTo = (ToInput.Text ?? string.Empty).Trim();
+        var subject = SubjectInput.Text;
+        var body = BodyInput.Text;
+
+        if (string.IsNullOrWhiteSpace(addressTo))
+        {
+            UriPreviewText.Text = "Recipient is required.";
+            return;
+        }
+
+        var uri = MailService.BuildMailtoUri(addressTo, subject, body);
+        UriPreviewText.Text = $"Launching: {uri.OriginalString}";
+
+        var launched = await _mail.ComposeMailAsync(addressTo, subject, body);
+        if (!launched)
+        {
+            UriPreviewText.Text += "\nLauncher returned false (no mail handler installed?).";
+        }
+    }
+}

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml
@@ -20,6 +20,7 @@
       <NavigationViewItem Content="ObservableCollection Merge" Tag="ObservableCollectionMerge" Icon="List" />
       <NavigationViewItemHeader Content="Platform" />
       <NavigationViewItem Content="Platform Services" Tag="PlatformServices" Icon="World" />
+      <NavigationViewItem Content="Mail Service" Tag="MailService" Icon="Mail" />
       <NavigationViewItemHeader Content="Infrastructure" />
       <NavigationViewItem Content="XamlRoot Provider" Tag="XamlRootProvider" Icon="Page" />
     </NavigationView.MenuItems>

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml.cs
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml.cs
@@ -31,6 +31,7 @@ public sealed partial class Shell : Page
                 "PackageVersion" => typeof(PackageVersionSamplePage),
                 "ObservableCollectionMerge" => typeof(ObservableCollectionMergeSamplePage),
                 "PlatformServices" => typeof(PlatformServicesSamplePage),
+                "MailService" => typeof(MailServiceSamplePage),
                 "XamlRootProvider" => typeof(XamlRootProviderSamplePage),
                 _ => null
             };

--- a/src/MZikmund.Toolkit.WinUI/Services/Platform/IMailService.cs
+++ b/src/MZikmund.Toolkit.WinUI/Services/Platform/IMailService.cs
@@ -1,0 +1,17 @@
+namespace MZikmund.Toolkit.WinUI.Services;
+
+/// <summary>
+/// Cross-platform <c>mailto:</c> launcher. Opens the user's default mail client
+/// pre-populated with the supplied recipient, subject, and body.
+/// </summary>
+public interface IMailService
+{
+    /// <summary>
+    /// Opens a new mail-compose window addressed to <paramref name="addressTo"/>.
+    /// </summary>
+    /// <param name="addressTo">Primary recipient.</param>
+    /// <param name="subject">Optional subject line.</param>
+    /// <param name="body">Optional body text.</param>
+    /// <returns><see langword="true"/> when the mail client launched successfully.</returns>
+    Task<bool> ComposeMailAsync(string addressTo, string? subject = null, string? body = null);
+}

--- a/src/MZikmund.Toolkit.WinUI/Services/Platform/MailService.cs
+++ b/src/MZikmund.Toolkit.WinUI/Services/Platform/MailService.cs
@@ -1,0 +1,64 @@
+using System.Text;
+
+namespace MZikmund.Toolkit.WinUI.Services;
+
+/// <summary>
+/// Default <see cref="IMailService"/> implementation. Builds an <c>mailto:</c> URI
+/// from the supplied parameters and dispatches it through <see cref="ILauncherService"/>.
+/// </summary>
+public sealed class MailService : IMailService
+{
+    private readonly ILauncherService _launcher;
+
+    /// <summary>Initializes a new instance using the supplied <paramref name="launcher"/>.</summary>
+    public MailService(ILauncherService launcher)
+    {
+        ArgumentNullException.ThrowIfNull(launcher);
+        _launcher = launcher;
+    }
+
+    /// <summary>Initializes a new instance using a default <see cref="LauncherService"/>.</summary>
+    public MailService() : this(new LauncherService())
+    {
+    }
+
+    /// <inheritdoc />
+    public Task<bool> ComposeMailAsync(string addressTo, string? subject = null, string? body = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(addressTo);
+
+        var uri = BuildMailtoUri(addressTo, subject, body);
+        return _launcher.LaunchUriAsync(uri);
+    }
+
+    /// <summary>
+    /// Builds the <c>mailto:</c> URI for the supplied parameters. Exposed for
+    /// testing; production code should call <see cref="ComposeMailAsync"/>.
+    /// </summary>
+    public static Uri BuildMailtoUri(string addressTo, string? subject, string? body)
+    {
+        // Mailto URIs use the raw email address — escaping the '@' breaks the parser.
+        var builder = new StringBuilder("mailto:");
+        builder.Append(addressTo);
+
+        var hasSubject = !string.IsNullOrEmpty(subject);
+        var hasBody = !string.IsNullOrEmpty(body);
+        if (hasSubject || hasBody)
+        {
+            builder.Append('?');
+            var first = true;
+            if (hasSubject)
+            {
+                builder.Append("subject=").Append(Uri.EscapeDataString(subject!));
+                first = false;
+            }
+            if (hasBody)
+            {
+                if (!first) builder.Append('&');
+                builder.Append("body=").Append(Uri.EscapeDataString(body!));
+            }
+        }
+
+        return new Uri(builder.ToString());
+    }
+}

--- a/tests/MZikmund.Toolkit.WinUI.Tests/MailServiceTests.cs
+++ b/tests/MZikmund.Toolkit.WinUI.Tests/MailServiceTests.cs
@@ -1,0 +1,88 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MZikmund.Toolkit.WinUI.Services;
+
+namespace MZikmund.Toolkit.WinUI.Tests;
+
+[TestClass]
+public class MailServiceTests
+{
+    [TestMethod]
+    public void Ctor_NullLauncher_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => new MailService(null!));
+    }
+
+    [TestMethod]
+    public void BuildMailtoUri_OnlyAddress_OmitsQuery()
+    {
+        var uri = MailService.BuildMailtoUri("a@example.com", subject: null, body: null);
+
+        Assert.AreEqual("mailto:a@example.com", uri.OriginalString);
+    }
+
+    [TestMethod]
+    public void BuildMailtoUri_WithSubject_AddsQuery()
+    {
+        var uri = MailService.BuildMailtoUri("a@example.com", subject: "Hello world", body: null);
+
+        Assert.AreEqual("mailto:a@example.com?subject=Hello%20world", uri.OriginalString);
+    }
+
+    [TestMethod]
+    public void BuildMailtoUri_WithBody_AddsBody()
+    {
+        var uri = MailService.BuildMailtoUri("a@example.com", subject: null, body: "Line1\nLine2");
+
+        Assert.AreEqual("mailto:a@example.com?body=Line1%0ALine2", uri.OriginalString);
+    }
+
+    [TestMethod]
+    public void BuildMailtoUri_WithSubjectAndBody_JoinsByAmpersand()
+    {
+        var uri = MailService.BuildMailtoUri("a@example.com", subject: "Re: question", body: "Hi.");
+
+        Assert.AreEqual("mailto:a@example.com?subject=Re%3A%20question&body=Hi.", uri.OriginalString);
+    }
+
+    [TestMethod]
+    public void BuildMailtoUri_EmptyStrings_TreatedAsAbsent()
+    {
+        var uri = MailService.BuildMailtoUri("a@example.com", subject: string.Empty, body: string.Empty);
+
+        Assert.AreEqual("mailto:a@example.com", uri.OriginalString);
+    }
+
+    [TestMethod]
+    public async Task ComposeMailAsync_NullOrWhitespaceAddress_Throws()
+    {
+        var service = new MailService(new CapturingLauncher());
+
+        await Assert.ThrowsAsync<ArgumentException>(() => service.ComposeMailAsync(null!));
+        await Assert.ThrowsAsync<ArgumentException>(() => service.ComposeMailAsync(string.Empty));
+        await Assert.ThrowsAsync<ArgumentException>(() => service.ComposeMailAsync("   "));
+    }
+
+    [TestMethod]
+    public async Task ComposeMailAsync_DispatchesBuiltUri_ToLauncher()
+    {
+        var launcher = new CapturingLauncher();
+        var service = new MailService(launcher);
+
+        await service.ComposeMailAsync("a@example.com", subject: "Hi", body: "Body");
+
+        Assert.AreEqual(
+            "mailto:a@example.com?subject=Hi&body=Body",
+            launcher.LastUri?.OriginalString);
+    }
+
+    private sealed class CapturingLauncher : ILauncherService
+    {
+        public Uri? LastUri { get; private set; }
+
+        public Task<bool> LaunchUriAsync(Uri uri)
+        {
+            LastUri = uri;
+            return Task.FromResult(true);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `IMailService` + `MailService` in `MZikmund.Toolkit.WinUI.Services`. `ComposeMailAsync(addressTo, subject, body)` builds a `mailto:` URI and dispatches it through `ILauncherService` (so the call is testable with a stub launcher and DI-friendly).
- URI building rules: subject and body are URL-encoded; the address is left raw because the `@` must not be percent-encoded for the OS mail handler to parse the URI. Empty / null subject and body are omitted from the query string.
- `BuildMailtoUri` is exposed `static` for tests and for callers that want to inspect or massage the URI before launch.
- Wires a gallery sample (`MailServiceSamplePage`) into Shell + HomePage with a To / Subject / Body form, a button that previews the built URI before launch.

### Note on the issue's two services

The issue covers two services:
- **`IMailService`** — added in this PR.
- **`ISystemSharingService`** — fulfilled by the `IShareService` promoted in #45 (this PR is stacked on it). Per the issue itself: "_ISystemSharingService is essentially the same class with a slightly different name — merge into ShareService during promotion._"

So both halves are landed: mail here, share via `IShareService` from #45.

Adds 8 unit tests covering the URI builder under each combination (only address, subject only, body only, both, empty strings), plus null-launcher / null-or-whitespace-address guards and end-to-end dispatch into a captured `ILauncherService`.

Closes #37

> **Stacked PR.** Targets `feature/issue-45-platform-services` (#77) for `ILauncherService`. Once #77 merges, retarget to `main` (or `feature/mergewith` if still in flight).

## Test plan

- [x] `dotnet build MZikmund.Toolkit.slnx -c Debug` succeeds.
- [x] Test exe reports 30/30 passed (22 prior + 8 new).
- [ ] Manually exercise the `Mail Service` sample on Windows: enter a recipient / subject / body, click `Open mail client`, confirm the system mail app launches with the fields populated and the preview URI matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)