### PR TITLE
feat: Add IThemeManager + AppTheme

### DIFF
--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/HomePage.xaml
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/HomePage.xaml
@@ -52,6 +52,12 @@
           <Run Text="Window Shell:" FontWeight="SemiBold" />
           <Run Text=" IWindowShell + IWindowShellProvider abstraction for window-scoped infrastructure (theme manager, dialogs, navigation)." />
         </TextBlock>
+
+        <TextBlock Style="{ThemeResource BodyTextBlockStyle}">
+          <Run Text="• " FontWeight="Bold" />
+          <Run Text="Theme Manager:" FontWeight="SemiBold" />
+          <Run Text=" IThemeManager persists user theme choice (System / Light / Dark) and applies it to the shell." />
+        </TextBlock>
       </StackPanel>
       
       <TextBlock Text="Navigation"

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/ThemeManagerSamplePage.xaml
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/ThemeManagerSamplePage.xaml
@@ -1,0 +1,75 @@
+<Page x:Class="MZikmund.Toolkit.Sample.ThemeManagerSamplePage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:local="using:MZikmund.Toolkit.Sample">
+
+  <ScrollViewer Padding="24">
+    <StackPanel Spacing="16" MaxWidth="800">
+      <TextBlock Text="IThemeManager"
+                 Style="{ThemeResource TitleTextBlockStyle}" />
+
+      <TextBlock Text="ThemeManager persists the user's theme choice (System / Light / Dark) through IPreferences and applies it to the active IWindowShell.RootFrame. Apps that need title-bar coloring or Mica tweaks subscribe to ThemeChanged."
+                 TextWrapping="Wrap"
+                 Style="{ThemeResource BodyTextBlockStyle}" />
+
+      <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+              BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+              BorderThickness="1"
+              CornerRadius="8"
+              Padding="16">
+        <StackPanel Spacing="12">
+          <TextBlock Text="Live theme switching"
+                     Style="{ThemeResource SubtitleTextBlockStyle}" />
+
+          <StackPanel Orientation="Horizontal" Spacing="8">
+            <Button Content="System" Click="System_Click" Style="{ThemeResource AccentButtonStyle}" />
+            <Button Content="Light" Click="Light_Click" />
+            <Button Content="Dark" Click="Dark_Click" />
+          </StackPanel>
+
+          <TextBlock x:Name="CurrentText" Style="{ThemeResource BodyStrongTextBlockStyle}" />
+
+          <Frame x:Name="ThemedFrame">
+            <Border BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                    BorderThickness="1"
+                    CornerRadius="6"
+                    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+                    Padding="16">
+              <StackPanel Spacing="8">
+                <TextBlock Text="This region lives inside ThemedFrame, the IWindowShell.RootFrame for this page."
+                           Style="{ThemeResource BodyStrongTextBlockStyle}"
+                           TextWrapping="Wrap" />
+                <TextBlock Text="Switching the theme above sets ThemedFrame.RequestedTheme through ThemeManager.Apply(); the inner controls re-render under the new theme."
+                           TextWrapping="Wrap" />
+                <TextBox PlaceholderText="A textbox to show theme contrast"
+                         MinWidth="200" />
+                <Button Content="A button" />
+              </StackPanel>
+            </Border>
+          </Frame>
+        </StackPanel>
+      </Border>
+
+      <Border Background="{ThemeResource LayerFillColorDefaultBrush}"
+              BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+              BorderThickness="1"
+              CornerRadius="8"
+              Padding="16">
+        <StackPanel Spacing="8">
+          <TextBlock Text="Code Sample"
+                     Style="{ThemeResource SubtitleTextBlockStyle}" />
+
+          <TextBlock FontFamily="Consolas" TextWrapping="Wrap">
+            <Run>using MZikmund.Toolkit.WinUI.Services;</Run><LineBreak />
+            <LineBreak />
+            <Run>// DI registration</Run><LineBreak />
+            <Run>services.AddSingleton&lt;IThemeManager, ThemeManager&gt;();</Run><LineBreak />
+            <LineBreak />
+            <Run>theme.SetTheme(AppTheme.Dark);</Run><LineBreak />
+            <Run>theme.ThemeChanged += (s, t) =&gt; UpdateTitleBarColors(t);</Run>
+          </TextBlock>
+        </StackPanel>
+      </Border>
+    </StackPanel>
+  </ScrollViewer>
+</Page>

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/ThemeManagerSamplePage.xaml.cs
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/ThemeManagerSamplePage.xaml.cs
@@ -1,0 +1,86 @@
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.UI.Dispatching;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using MZikmund.Toolkit.WinUI.Infrastructure;
+using MZikmund.Toolkit.WinUI.Services;
+
+namespace MZikmund.Toolkit.Sample;
+
+public sealed partial class ThemeManagerSamplePage : Page, IWindowShell
+{
+    private readonly WindowShellProvider _shellProvider = new();
+    private readonly InMemoryPreferences _preferences = new();
+    private readonly IThemeManager _themeManager;
+
+    public ThemeManagerSamplePage()
+    {
+        this.InitializeComponent();
+        _shellProvider.SetShell(this);
+        _themeManager = new ThemeManager(_shellProvider, _preferences);
+        _themeManager.Apply();
+        UpdateText();
+    }
+
+    public object? ViewModel => null;
+
+    public new XamlRoot XamlRoot => base.XamlRoot;
+
+    public IServiceProvider ServiceProvider => null!;
+
+    public new DispatcherQueue DispatcherQueue => base.DispatcherQueue;
+
+    public Frame RootFrame => ThemedFrame;
+
+    public void SetTitleBar(UIElement titleBar)
+    {
+    }
+
+    private void System_Click(object sender, RoutedEventArgs e) => Apply(AppTheme.System);
+
+    private void Light_Click(object sender, RoutedEventArgs e) => Apply(AppTheme.Light);
+
+    private void Dark_Click(object sender, RoutedEventArgs e) => Apply(AppTheme.Dark);
+
+    private void Apply(AppTheme theme)
+    {
+        _themeManager.SetTheme(theme);
+        UpdateText();
+    }
+
+    private void UpdateText()
+    {
+        CurrentText.Text = $"Current theme: {_themeManager.CurrentTheme} (frame.RequestedTheme = {ThemedFrame.RequestedTheme})";
+    }
+
+    private sealed class InMemoryPreferences : IPreferences
+    {
+        private readonly Dictionary<string, object?> _values = new();
+
+        public T Get<T>(string key, T defaultValue) =>
+            _values.TryGetValue(key, out var v) && v is T typed ? typed : defaultValue;
+
+        public bool TryGet<T>(string key, [MaybeNullWhen(false)] out T value)
+        {
+            if (_values.TryGetValue(key, out var v) && v is T typed)
+            {
+                value = typed;
+                return true;
+            }
+            value = default;
+            return false;
+        }
+
+        public void Set<T>(string key, T? value)
+        {
+            if (value is null) _values.Remove(key);
+            else _values[key] = value;
+        }
+
+        public T GetComplex<T>(string key, T defaultValue) => Get(key, defaultValue);
+
+        public bool TryGetComplex<T>(string key, [MaybeNullWhen(false)] out T value) => TryGet(key, out value);
+
+        public void SetComplex<T>(string key, T? value) => Set(key, value);
+    }
+}

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml
@@ -21,6 +21,7 @@
       <NavigationViewItemHeader Content="Infrastructure" />
       <NavigationViewItem Content="XamlRoot Provider" Tag="XamlRootProvider" Icon="Page" />
       <NavigationViewItem Content="Window Shell" Tag="WindowShell" Icon="NewWindow" />
+      <NavigationViewItem Content="Theme Manager" Tag="ThemeManager" Icon="Highlight" />
     </NavigationView.MenuItems>
 
     <Frame x:Name="ContentFrame" />

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml.cs
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml.cs
@@ -32,6 +32,7 @@ public sealed partial class Shell : Page
                 "ObservableCollectionMerge" => typeof(ObservableCollectionMergeSamplePage),
                 "XamlRootProvider" => typeof(XamlRootProviderSamplePage),
                 "WindowShell" => typeof(WindowShellSamplePage),
+                "ThemeManager" => typeof(ThemeManagerSamplePage),
                 _ => null
             };
 

--- a/src/MZikmund.Toolkit.WinUI/Services/Theming/AppTheme.cs
+++ b/src/MZikmund.Toolkit.WinUI/Services/Theming/AppTheme.cs
@@ -1,0 +1,17 @@
+namespace MZikmund.Toolkit.WinUI.Services;
+
+/// <summary>
+/// User-facing theme choice for an app: <see cref="System"/> follows the OS,
+/// <see cref="Light"/> / <see cref="Dark"/> override it.
+/// </summary>
+public enum AppTheme
+{
+    /// <summary>Follow the operating system's current theme.</summary>
+    System = 0,
+
+    /// <summary>Light theme regardless of the OS setting.</summary>
+    Light,
+
+    /// <summary>Dark theme regardless of the OS setting.</summary>
+    Dark,
+}

--- a/src/MZikmund.Toolkit.WinUI/Services/Theming/IThemeManager.cs
+++ b/src/MZikmund.Toolkit.WinUI/Services/Theming/IThemeManager.cs
@@ -1,0 +1,28 @@
+namespace MZikmund.Toolkit.WinUI.Services;
+
+/// <summary>
+/// Manages the user-facing app theme. Persists the choice through the toolkit's
+/// preferences service and applies it to the active <c>IWindowShell</c>'s root
+/// element. Apps that need title-bar coloring or Mica adjustments subscribe to
+/// <see cref="ThemeChanged"/> and update from there.
+/// </summary>
+public interface IThemeManager
+{
+    /// <summary>The currently selected theme.</summary>
+    AppTheme CurrentTheme { get; }
+
+    /// <summary>Raised after <see cref="SetTheme"/> applies a new theme.</summary>
+    event EventHandler<AppTheme>? ThemeChanged;
+
+    /// <summary>
+    /// Persists <paramref name="theme"/>, applies it to the shell's root element,
+    /// and raises <see cref="ThemeChanged"/>.
+    /// </summary>
+    void SetTheme(AppTheme theme);
+
+    /// <summary>
+    /// Re-applies <see cref="CurrentTheme"/> to the shell. Useful at shell startup
+    /// to restore the persisted theme on a freshly-created root element.
+    /// </summary>
+    void Apply();
+}

--- a/src/MZikmund.Toolkit.WinUI/Services/Theming/ThemeManager.cs
+++ b/src/MZikmund.Toolkit.WinUI/Services/Theming/ThemeManager.cs
@@ -1,0 +1,61 @@
+using Microsoft.UI.Xaml;
+using MZikmund.Toolkit.WinUI.Infrastructure;
+
+namespace MZikmund.Toolkit.WinUI.Services;
+
+/// <summary>
+/// Default <see cref="IThemeManager"/>. Persists the user's theme choice through
+/// <see cref="IPreferences"/> and applies it to <see cref="IWindowShell.RootFrame"/>'s
+/// <see cref="FrameworkElement.RequestedTheme"/>. Apps that need title-bar coloring
+/// subscribe to <see cref="ThemeChanged"/>.
+/// </summary>
+public sealed class ThemeManager : IThemeManager
+{
+    private const string ThemePreferenceKey = "MZikmund.Toolkit.Theme";
+
+    private readonly IWindowShellProvider _shellProvider;
+    private readonly IPreferences _preferences;
+
+    /// <summary>Initializes a new instance.</summary>
+    public ThemeManager(IWindowShellProvider shellProvider, IPreferences preferences)
+    {
+        ArgumentNullException.ThrowIfNull(shellProvider);
+        ArgumentNullException.ThrowIfNull(preferences);
+        _shellProvider = shellProvider;
+        _preferences = preferences;
+
+        CurrentTheme = preferences.Get(ThemePreferenceKey, AppTheme.System);
+    }
+
+    /// <inheritdoc />
+    public AppTheme CurrentTheme { get; private set; }
+
+    /// <inheritdoc />
+    public event EventHandler<AppTheme>? ThemeChanged;
+
+    /// <inheritdoc />
+    public void SetTheme(AppTheme theme)
+    {
+        CurrentTheme = theme;
+        _preferences.Set(ThemePreferenceKey, theme);
+        Apply();
+        ThemeChanged?.Invoke(this, theme);
+    }
+
+    /// <inheritdoc />
+    public void Apply()
+    {
+        if (_shellProvider.Shell.RootFrame is { } frame)
+        {
+            frame.RequestedTheme = ToElementTheme(CurrentTheme);
+        }
+    }
+
+    /// <summary>Maps an <see cref="AppTheme"/> to a WinUI <see cref="ElementTheme"/>.</summary>
+    public static ElementTheme ToElementTheme(AppTheme theme) => theme switch
+    {
+        AppTheme.Light => ElementTheme.Light,
+        AppTheme.Dark => ElementTheme.Dark,
+        _ => ElementTheme.Default,
+    };
+}

--- a/tests/MZikmund.Toolkit.WinUI.Tests/ThemeManagerTests.cs
+++ b/tests/MZikmund.Toolkit.WinUI.Tests/ThemeManagerTests.cs
@@ -1,0 +1,130 @@
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.UI.Dispatching;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MZikmund.Toolkit.WinUI.Infrastructure;
+using MZikmund.Toolkit.WinUI.Services;
+
+namespace MZikmund.Toolkit.WinUI.Tests;
+
+[TestClass]
+public class ThemeManagerTests
+{
+    [TestMethod]
+    public void Ctor_NullArgs_Throw()
+    {
+        var prefs = new InMemoryPreferences();
+        var provider = new WindowShellProvider();
+
+        Assert.Throws<ArgumentNullException>(() => new ThemeManager(null!, prefs));
+        Assert.Throws<ArgumentNullException>(() => new ThemeManager(provider, null!));
+    }
+
+    [TestMethod]
+    public void CurrentTheme_DefaultsToSystem_OnFreshPreferences()
+    {
+        var manager = CreateManager(new InMemoryPreferences());
+
+        Assert.AreEqual(AppTheme.System, manager.CurrentTheme);
+    }
+
+    [TestMethod]
+    public void CurrentTheme_LoadsFromPreferences()
+    {
+        var prefs = new InMemoryPreferences();
+        prefs.Set("MZikmund.Toolkit.Theme", AppTheme.Dark);
+
+        var manager = CreateManager(prefs);
+
+        Assert.AreEqual(AppTheme.Dark, manager.CurrentTheme);
+    }
+
+    [TestMethod]
+    public void SetTheme_PersistsAndUpdatesCurrent()
+    {
+        var prefs = new InMemoryPreferences();
+        var manager = CreateManager(prefs);
+
+        manager.SetTheme(AppTheme.Light);
+
+        Assert.AreEqual(AppTheme.Light, manager.CurrentTheme);
+        Assert.AreEqual(AppTheme.Light, prefs.Get("MZikmund.Toolkit.Theme", AppTheme.System));
+    }
+
+    [TestMethod]
+    public void SetTheme_RaisesThemeChanged_WithNewValue()
+    {
+        var manager = CreateManager(new InMemoryPreferences());
+        AppTheme? captured = null;
+        manager.ThemeChanged += (_, theme) => captured = theme;
+
+        manager.SetTheme(AppTheme.Dark);
+
+        Assert.AreEqual(AppTheme.Dark, captured);
+    }
+
+    [TestMethod]
+    public void ToElementTheme_MapsCorrectly()
+    {
+        Assert.AreEqual(ElementTheme.Default, ThemeManager.ToElementTheme(AppTheme.System));
+        Assert.AreEqual(ElementTheme.Light, ThemeManager.ToElementTheme(AppTheme.Light));
+        Assert.AreEqual(ElementTheme.Dark, ThemeManager.ToElementTheme(AppTheme.Dark));
+    }
+
+    private static ThemeManager CreateManager(IPreferences preferences)
+    {
+        var provider = new WindowShellProvider();
+        provider.SetShell(new StubShell());
+        return new ThemeManager(provider, preferences);
+    }
+
+    private sealed class StubShell : IWindowShell
+    {
+        public object? ViewModel => null;
+
+        public XamlRoot XamlRoot => null!;
+
+        public IServiceProvider ServiceProvider => null!;
+
+        public DispatcherQueue DispatcherQueue => null!;
+
+        // ThemeManager.Apply is null-safe — RootFrame=null skips the assignment.
+        public Frame RootFrame => null!;
+
+        public void SetTitleBar(UIElement titleBar)
+        {
+        }
+    }
+
+    private sealed class InMemoryPreferences : IPreferences
+    {
+        private readonly Dictionary<string, object?> _values = new();
+
+        public T Get<T>(string key, T defaultValue) =>
+            _values.TryGetValue(key, out var v) && v is T typed ? typed : defaultValue;
+
+        public bool TryGet<T>(string key, [MaybeNullWhen(false)] out T value)
+        {
+            if (_values.TryGetValue(key, out var v) && v is T typed)
+            {
+                value = typed;
+                return true;
+            }
+            value = default;
+            return false;
+        }
+
+        public void Set<T>(string key, T? value)
+        {
+            if (value is null) _values.Remove(key);
+            else _values[key] = value;
+        }
+
+        public T GetComplex<T>(string key, T defaultValue) => Get(key, defaultValue);
+
+        public bool TryGetComplex<T>(string key, [MaybeNullWhen(false)] out T value) => TryGet(key, out value);
+
+        public void SetComplex<T>(string key, T? value) => Set(key, value);
+    }
+}


### PR DESCRIPTION
## Summary

Adds the theming service from `uno-app-template` under `MZikmund.Toolkit.WinUI.Services`:

- **`AppTheme`** — `System` / `Light` / `Dark` enum.
- **`IThemeManager`** — `CurrentTheme`, `SetTheme`, `Apply`, and a `ThemeChanged` event.
- **`ThemeManager`** — persists the choice through `IPreferences` and applies it to the active `IWindowShell.RootFrame.RequestedTheme`. `Apply()` re-applies the persisted theme on a freshly-created shell root (call once at shell startup). `SetTheme` does persist + apply + raise.

Title-bar coloring and Mica adjustments are intentionally out of scope here — those need window-handle access that `IWindowShell` doesn't surface. Apps subscribe to `ThemeChanged` and customize from there.

Wires a gallery sample (`ThemeManagerSamplePage`) into Shell + HomePage. The page itself implements `IWindowShell` with its own `Frame`, so the `System` / `Light` / `Dark` buttons flip the colors of a hosted region in real time without requiring app-level integration.

Adds 6 unit tests covering null-arg guards, the default-on-fresh-prefs behavior, loading from persisted preferences, persisting on `SetTheme`, the `ThemeChanged` event, and the `AppTheme` → `ElementTheme` mapping. Tests use a stubbed `IWindowShell` whose `RootFrame` is null — `Apply()` is null-safe in that case.

Closes #49

> **Stacked PR.** Targets `feature/issue-51-window-shell` (#70) — depends on `IWindowShellProvider`. Once #70 merges, retarget to `main`.

## Test plan

- [x] `dotnet build MZikmund.Toolkit.slnx -c Debug` succeeds.
- [x] Test exe reports 24/24 passed (18 prior + 6 new).
- [ ] Manually exercise the `Theme Manager` sample on Windows: click `Light` and confirm the hosted region flips to a light theme; click `Dark` and confirm it flips back; click `System` and confirm it follows the OS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)