### PR TITLE
feat: Add INavigationService + NavigationInfoAttribute

### DIFF
--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/HomePage.xaml
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/HomePage.xaml
@@ -52,6 +52,12 @@
           <Run Text="Window Shell:" FontWeight="SemiBold" />
           <Run Text=" IWindowShell + IWindowShellProvider abstraction for window-scoped infrastructure (theme manager, dialogs, navigation)." />
         </TextBlock>
+
+        <TextBlock Style="{ThemeResource BodyTextBlockStyle}">
+          <Run Text="• " FontWeight="Bold" />
+          <Run Text="Navigation:" FontWeight="SemiBold" />
+          <Run Text=" INavigationService + NavigationInfoAttribute (string section tags, NavigationTransition)." />
+        </TextBlock>
       </StackPanel>
       
       <TextBlock Text="Navigation"

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/NavigationDemoMainPage.xaml
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/NavigationDemoMainPage.xaml
@@ -1,0 +1,11 @@
+<Page x:Class="MZikmund.Toolkit.Sample.NavigationDemoMainPage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:local="using:MZikmund.Toolkit.Sample">
+  <Border Padding="16"
+          Background="{ThemeResource AccentFillColorDefaultBrush}">
+    <TextBlock Text="Main page (NavigationInfo: section=&quot;main&quot;, transition=FromRight)"
+               Foreground="{ThemeResource TextOnAccentFillColorPrimaryBrush}"
+               TextWrapping="Wrap" />
+  </Border>
+</Page>

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/NavigationDemoMainPage.xaml.cs
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/NavigationDemoMainPage.xaml.cs
@@ -1,0 +1,13 @@
+using Microsoft.UI.Xaml.Controls;
+using MZikmund.Toolkit.WinUI.Navigation;
+
+namespace MZikmund.Toolkit.Sample;
+
+[NavigationInfo("main", NavigationTransition.FromRight)]
+public sealed partial class NavigationDemoMainPage : Page
+{
+    public NavigationDemoMainPage()
+    {
+        this.InitializeComponent();
+    }
+}

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/NavigationDemoSettingsPage.xaml
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/NavigationDemoSettingsPage.xaml
@@ -1,0 +1,11 @@
+<Page x:Class="MZikmund.Toolkit.Sample.NavigationDemoSettingsPage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:local="using:MZikmund.Toolkit.Sample">
+  <Border Padding="16"
+          Background="{ThemeResource SystemFillColorAttentionBrush}">
+    <TextBlock Text="Settings page (NavigationInfo: section=&quot;settings&quot;, transition=FromBottom)"
+               Foreground="{ThemeResource TextOnAccentFillColorPrimaryBrush}"
+               TextWrapping="Wrap" />
+  </Border>
+</Page>

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/NavigationDemoSettingsPage.xaml.cs
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/NavigationDemoSettingsPage.xaml.cs
@@ -1,0 +1,13 @@
+using Microsoft.UI.Xaml.Controls;
+using MZikmund.Toolkit.WinUI.Navigation;
+
+namespace MZikmund.Toolkit.Sample;
+
+[NavigationInfo("settings", NavigationTransition.FromBottom)]
+public sealed partial class NavigationDemoSettingsPage : Page
+{
+    public NavigationDemoSettingsPage()
+    {
+        this.InitializeComponent();
+    }
+}

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/NavigationSamplePage.xaml
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/NavigationSamplePage.xaml
@@ -1,0 +1,68 @@
+<Page x:Class="MZikmund.Toolkit.Sample.NavigationSamplePage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:local="using:MZikmund.Toolkit.Sample">
+
+  <ScrollViewer Padding="24">
+    <StackPanel Spacing="16" MaxWidth="800">
+      <TextBlock Text="INavigationService"
+                 Style="{ThemeResource TitleTextBlockStyle}" />
+
+      <TextBlock Text="NavigationService is a thin wrapper over Frame that reads NavigationInfoAttribute on destination pages — section tag for highlighting NavigationView items and transition to play. Section tags are strings (not a hard-coded enum) so apps own their own taxonomy."
+                 TextWrapping="Wrap"
+                 Style="{ThemeResource BodyTextBlockStyle}" />
+
+      <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+              BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+              BorderThickness="1"
+              CornerRadius="8"
+              Padding="16">
+        <StackPanel Spacing="12">
+          <TextBlock Text="Live demo"
+                     Style="{ThemeResource SubtitleTextBlockStyle}" />
+
+          <StackPanel Orientation="Horizontal" Spacing="8">
+            <Button Content="Go to Main" Click="GotoMain_Click" Style="{ThemeResource AccentButtonStyle}" />
+            <Button Content="Go to Settings" Click="GotoSettings_Click" />
+            <Button Content="Back" Click="Back_Click" />
+          </StackPanel>
+
+          <TextBlock x:Name="StatusText" Style="{ThemeResource BodyStrongTextBlockStyle}" />
+
+          <Frame x:Name="HostedFrame">
+            <Frame.ContentTransitions>
+              <TransitionCollection />
+            </Frame.ContentTransitions>
+          </Frame>
+        </StackPanel>
+      </Border>
+
+      <Border Background="{ThemeResource LayerFillColorDefaultBrush}"
+              BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+              BorderThickness="1"
+              CornerRadius="8"
+              Padding="16">
+        <StackPanel Spacing="8">
+          <TextBlock Text="Code Sample"
+                     Style="{ThemeResource SubtitleTextBlockStyle}" />
+
+          <TextBlock FontFamily="Consolas" TextWrapping="Wrap">
+            <Run>using MZikmund.Toolkit.WinUI.Navigation;</Run><LineBreak />
+            <Run>using MZikmund.Toolkit.WinUI.Services;</Run><LineBreak />
+            <LineBreak />
+            <Run>public static class AppSections</Run><LineBreak />
+            <Run>{</Run><LineBreak />
+            <Run>    public const string Main = "main";</Run><LineBreak />
+            <Run>    public const string Settings = "settings";</Run><LineBreak />
+            <Run>}</Run><LineBreak />
+            <LineBreak />
+            <Run>[NavigationInfo(AppSections.Settings, NavigationTransition.FromRight)]</Run><LineBreak />
+            <Run>public sealed partial class SettingsPage : Page { }</Run><LineBreak />
+            <LineBreak />
+            <Run>nav.Navigate(typeof(SettingsPage));  // CurrentSection becomes "settings"</Run>
+          </TextBlock>
+        </StackPanel>
+      </Border>
+    </StackPanel>
+  </ScrollViewer>
+</Page>

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/NavigationSamplePage.xaml.cs
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/NavigationSamplePage.xaml.cs
@@ -1,0 +1,51 @@
+using Microsoft.UI.Dispatching;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using MZikmund.Toolkit.WinUI.Infrastructure;
+using MZikmund.Toolkit.WinUI.Services;
+
+namespace MZikmund.Toolkit.Sample;
+
+public sealed partial class NavigationSamplePage : Page, IWindowShell
+{
+    private readonly WindowShellProvider _shellProvider = new();
+    private readonly INavigationService _navigation;
+
+    public NavigationSamplePage()
+    {
+        this.InitializeComponent();
+        _shellProvider.SetShell(this);
+        _navigation = new NavigationService(_shellProvider);
+        _navigation.Navigated += (s, e) => UpdateStatus();
+        UpdateStatus();
+    }
+
+    public object? ViewModel => null;
+
+    public new XamlRoot XamlRoot => base.XamlRoot;
+
+    public IServiceProvider ServiceProvider => null!;
+
+    public new DispatcherQueue DispatcherQueue => base.DispatcherQueue;
+
+    public Frame RootFrame => HostedFrame;
+
+    public void SetTitleBar(UIElement titleBar)
+    {
+    }
+
+    private void GotoMain_Click(object sender, RoutedEventArgs e) =>
+        _navigation.Navigate(typeof(NavigationDemoMainPage));
+
+    private void GotoSettings_Click(object sender, RoutedEventArgs e) =>
+        _navigation.Navigate(typeof(NavigationDemoSettingsPage));
+
+    private void Back_Click(object sender, RoutedEventArgs e) =>
+        _navigation.GoBack();
+
+    private void UpdateStatus()
+    {
+        StatusText.Text =
+            $"CurrentSection: {_navigation.CurrentSection ?? "(null)"}, CanGoBack: {_navigation.CanGoBack}";
+    }
+}

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml
@@ -21,6 +21,7 @@
       <NavigationViewItemHeader Content="Infrastructure" />
       <NavigationViewItem Content="XamlRoot Provider" Tag="XamlRootProvider" Icon="Page" />
       <NavigationViewItem Content="Window Shell" Tag="WindowShell" Icon="NewWindow" />
+      <NavigationViewItem Content="Navigation" Tag="Navigation" Icon="Forward" />
     </NavigationView.MenuItems>
 
     <Frame x:Name="ContentFrame" />

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml.cs
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml.cs
@@ -32,6 +32,7 @@ public sealed partial class Shell : Page
                 "ObservableCollectionMerge" => typeof(ObservableCollectionMergeSamplePage),
                 "XamlRootProvider" => typeof(XamlRootProviderSamplePage),
                 "WindowShell" => typeof(WindowShellSamplePage),
+                "Navigation" => typeof(NavigationSamplePage),
                 _ => null
             };
 

--- a/src/MZikmund.Toolkit.WinUI/Navigation/NavigationInfoAttribute.cs
+++ b/src/MZikmund.Toolkit.WinUI/Navigation/NavigationInfoAttribute.cs
@@ -1,0 +1,37 @@
+namespace MZikmund.Toolkit.WinUI.Navigation;
+
+/// <summary>
+/// Tags a page with metadata the navigation service uses: which logical "section" it
+/// belongs to (for highlighting NavigationView items, etc.) and which transition to play
+/// when navigating to it.
+/// </summary>
+/// <remarks>
+/// <para>The toolkit uses string section tags rather than a hard-coded enum so apps
+/// own their own section taxonomy. A typical app declares a static helper class like:</para>
+/// <code>
+/// public static class AppSections
+/// {
+///     public const string Main = "main";
+///     public const string Settings = "settings";
+/// }
+/// </code>
+/// </remarks>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+public sealed class NavigationInfoAttribute : Attribute
+{
+    /// <summary>Initializes a new instance.</summary>
+    /// <param name="sectionTag">Logical section the page belongs to.</param>
+    /// <param name="transition">Transition to play when navigating to the page.</param>
+    public NavigationInfoAttribute(string sectionTag, NavigationTransition transition = NavigationTransition.Default)
+    {
+        ArgumentNullException.ThrowIfNull(sectionTag);
+        SectionTag = sectionTag;
+        Transition = transition;
+    }
+
+    /// <summary>Logical section tag.</summary>
+    public string SectionTag { get; }
+
+    /// <summary>Transition to play when navigating to the decorated page.</summary>
+    public NavigationTransition Transition { get; }
+}

--- a/src/MZikmund.Toolkit.WinUI/Navigation/NavigationTransition.cs
+++ b/src/MZikmund.Toolkit.WinUI/Navigation/NavigationTransition.cs
@@ -1,0 +1,23 @@
+namespace MZikmund.Toolkit.WinUI.Navigation;
+
+/// <summary>
+/// Page-to-page transition style used by <see cref="NavigationInfoAttribute"/> and
+/// the navigation service. Maps to a <c>NavigationTransitionInfo</c> at navigate time.
+/// </summary>
+public enum NavigationTransition
+{
+    /// <summary>Use the frame's default transition.</summary>
+    Default = 0,
+
+    /// <summary>Suppress the transition animation.</summary>
+    Suppress,
+
+    /// <summary>Slide in from the right (typical "drill-down").</summary>
+    FromRight,
+
+    /// <summary>Slide in from the left.</summary>
+    FromLeft,
+
+    /// <summary>Slide in from the bottom (typical "modal sheet").</summary>
+    FromBottom,
+}

--- a/src/MZikmund.Toolkit.WinUI/Services/Navigation/INavigationService.cs
+++ b/src/MZikmund.Toolkit.WinUI/Services/Navigation/INavigationService.cs
@@ -1,0 +1,30 @@
+using MZikmund.Toolkit.WinUI.Navigation;
+
+namespace MZikmund.Toolkit.WinUI.Services;
+
+/// <summary>
+/// Frame-based navigation service that consumes <see cref="NavigationInfoAttribute"/>
+/// metadata on page types: section tag for highlighting and transition for animation.
+/// </summary>
+public interface INavigationService
+{
+    /// <summary>The section tag of the most recently navigated-to page, or <see langword="null"/> if untagged.</summary>
+    string? CurrentSection { get; }
+
+    /// <summary><see langword="true"/> when the underlying frame can navigate back.</summary>
+    bool CanGoBack { get; }
+
+    /// <summary>Raised after a successful navigation.</summary>
+    event EventHandler? Navigated;
+
+    /// <summary>
+    /// Navigates the shell's root frame to <paramref name="pageType"/>, applying the
+    /// transition declared on its <see cref="NavigationInfoAttribute"/> (if any).
+    /// </summary>
+    /// <returns><see langword="true"/> if the navigation started.</returns>
+    bool Navigate(Type pageType, object? parameter = null);
+
+    /// <summary>Navigates back if <see cref="CanGoBack"/> is true.</summary>
+    /// <returns><see langword="true"/> if a back navigation occurred.</returns>
+    bool GoBack();
+}

--- a/src/MZikmund.Toolkit.WinUI/Services/Navigation/NavigationService.cs
+++ b/src/MZikmund.Toolkit.WinUI/Services/Navigation/NavigationService.cs
@@ -1,0 +1,109 @@
+using System.Reflection;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media.Animation;
+using Microsoft.UI.Xaml.Navigation;
+using MZikmund.Toolkit.WinUI.Infrastructure;
+using MZikmund.Toolkit.WinUI.Navigation;
+
+namespace MZikmund.Toolkit.WinUI.Services;
+
+/// <summary>
+/// Default <see cref="INavigationService"/> implementation. Resolves the active
+/// <see cref="Frame"/> through <see cref="IWindowShellProvider"/>, attaches to
+/// <see cref="Frame.Navigated"/> the first time it sees the frame, reads
+/// <see cref="NavigationInfoAttribute"/> on each destination type, and dispatches
+/// the corresponding <see cref="NavigationTransitionInfo"/>.
+/// </summary>
+public sealed class NavigationService : INavigationService
+{
+    private readonly IWindowShellProvider _shellProvider;
+    private Frame? _subscribedFrame;
+
+    /// <summary>Initializes a new instance.</summary>
+    public NavigationService(IWindowShellProvider shellProvider)
+    {
+        ArgumentNullException.ThrowIfNull(shellProvider);
+        _shellProvider = shellProvider;
+    }
+
+    /// <inheritdoc />
+    public string? CurrentSection { get; private set; }
+
+    /// <inheritdoc />
+    public bool CanGoBack => GetFrame()?.CanGoBack ?? false;
+
+    /// <inheritdoc />
+    public event EventHandler? Navigated;
+
+    /// <inheritdoc />
+    public bool Navigate(Type pageType, object? parameter = null)
+    {
+        ArgumentNullException.ThrowIfNull(pageType);
+
+        var frame = GetFrame()
+            ?? throw new InvalidOperationException("No IWindowShell.RootFrame available — register an IWindowShell before navigating.");
+
+        var info = pageType.GetCustomAttribute<NavigationInfoAttribute>();
+        var transition = info?.Transition ?? NavigationTransition.Default;
+        return frame.Navigate(pageType, parameter, BuildTransitionInfo(transition));
+    }
+
+    /// <inheritdoc />
+    public bool GoBack()
+    {
+        var frame = GetFrame();
+        if (frame is null || !frame.CanGoBack)
+        {
+            return false;
+        }
+
+        frame.GoBack();
+        return true;
+    }
+
+    /// <summary>
+    /// Maps a <see cref="NavigationTransition"/> to its corresponding <see cref="NavigationTransitionInfo"/>
+    /// (or <see langword="null"/> for the frame's default).
+    /// </summary>
+    public static NavigationTransitionInfo? BuildTransitionInfo(NavigationTransition transition) => transition switch
+    {
+        NavigationTransition.Suppress => new SuppressNavigationTransitionInfo(),
+        NavigationTransition.FromRight => new SlideNavigationTransitionInfo { Effect = SlideNavigationTransitionEffect.FromRight },
+        NavigationTransition.FromLeft => new SlideNavigationTransitionInfo { Effect = SlideNavigationTransitionEffect.FromLeft },
+        NavigationTransition.FromBottom => new SlideNavigationTransitionInfo { Effect = SlideNavigationTransitionEffect.FromBottom },
+        _ => null,
+    };
+
+    private Frame? GetFrame()
+    {
+        Frame? frame;
+        try
+        {
+            frame = _shellProvider.Shell.RootFrame;
+        }
+        catch (InvalidOperationException)
+        {
+            return null;
+        }
+
+        if (frame is not null && !ReferenceEquals(_subscribedFrame, frame))
+        {
+            if (_subscribedFrame is not null)
+            {
+                _subscribedFrame.Navigated -= OnFrameNavigated;
+            }
+
+            frame.Navigated += OnFrameNavigated;
+            _subscribedFrame = frame;
+        }
+
+        return frame;
+    }
+
+    private void OnFrameNavigated(object sender, NavigationEventArgs e)
+    {
+        var info = e.SourcePageType?.GetCustomAttribute<NavigationInfoAttribute>();
+        CurrentSection = info?.SectionTag;
+        Navigated?.Invoke(this, EventArgs.Empty);
+    }
+}

--- a/tests/MZikmund.Toolkit.WinUI.Tests/NavigationTests.cs
+++ b/tests/MZikmund.Toolkit.WinUI.Tests/NavigationTests.cs
@@ -1,0 +1,94 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MZikmund.Toolkit.WinUI.Infrastructure;
+using MZikmund.Toolkit.WinUI.Navigation;
+using MZikmund.Toolkit.WinUI.Services;
+
+namespace MZikmund.Toolkit.WinUI.Tests;
+
+[TestClass]
+public class NavigationInfoAttributeTests
+{
+    [TestMethod]
+    public void Ctor_NullSection_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => new NavigationInfoAttribute(null!));
+    }
+
+    [TestMethod]
+    public void Ctor_DefaultsTransitionToDefault()
+    {
+        var attr = new NavigationInfoAttribute("main");
+
+        Assert.AreEqual("main", attr.SectionTag);
+        Assert.AreEqual(NavigationTransition.Default, attr.Transition);
+    }
+
+    [TestMethod]
+    public void Ctor_AcceptsCustomTransition()
+    {
+        var attr = new NavigationInfoAttribute("settings", NavigationTransition.FromBottom);
+
+        Assert.AreEqual("settings", attr.SectionTag);
+        Assert.AreEqual(NavigationTransition.FromBottom, attr.Transition);
+    }
+
+    [TestMethod]
+    public void Attribute_DiscoverableViaReflection()
+    {
+        var attr = typeof(TaggedPage).GetCustomAttributes(typeof(NavigationInfoAttribute), false);
+
+        Assert.AreEqual(1, attr.Length);
+        Assert.AreEqual("demo", ((NavigationInfoAttribute)attr[0]).SectionTag);
+    }
+
+    [NavigationInfo("demo")]
+    private sealed class TaggedPage
+    {
+    }
+}
+
+[TestClass]
+public class NavigationServiceTransitionTests
+{
+    // BuildTransitionInfo round-trips can't be exercised in the headless test runner
+    // because instantiating WinUI's NavigationTransitionInfo subclasses fails with
+    // "Ref assembly" (the reference assemblies have no implementation). The default-
+    // returns-null branch is still safe to test since it doesn't instantiate anything.
+
+    [TestMethod]
+    public void BuildTransitionInfo_Default_ReturnsNull()
+    {
+        Assert.IsNull(NavigationService.BuildTransitionInfo(NavigationTransition.Default));
+    }
+
+    [TestMethod]
+    public void Ctor_NullProvider_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => new NavigationService(null!));
+    }
+
+    [TestMethod]
+    public void Navigate_NullPageType_Throws()
+    {
+        var service = new NavigationService(new WindowShellProvider());
+
+        Assert.Throws<ArgumentNullException>(() => service.Navigate(null!));
+    }
+
+    [TestMethod]
+    public void Navigate_BeforeShellRegistered_Throws()
+    {
+        // No shell registered → InvalidOperationException with a helpful message.
+        var service = new NavigationService(new WindowShellProvider());
+
+        Assert.Throws<InvalidOperationException>(() => service.Navigate(typeof(object)));
+    }
+
+    [TestMethod]
+    public void GoBack_BeforeShellRegistered_ReturnsFalse()
+    {
+        var service = new NavigationService(new WindowShellProvider());
+
+        Assert.IsFalse(service.GoBack());
+    }
+}


### PR DESCRIPTION
## Summary

Promotes the navigation infrastructure from `uno-app-template` under `MZikmund.Toolkit.WinUI`:

- `Navigation/NavigationTransition` — `Default`, `Suppress`, `FromRight`, `FromLeft`, `FromBottom`.
- `Navigation/NavigationInfoAttribute` — decorates `Page` types with a section tag + `NavigationTransition`. **The "blocking refactor" called out in the issue is done**: the section tag is a `string`, not the template's hard-coded `NavigationSection` enum, so apps own their own taxonomy (`AppSections.Main = "main"`).
- `Services/Navigation/INavigationService` — `Navigate`, `GoBack`, `CurrentSection`, `CanGoBack`, `Navigated` event.
- `Services/Navigation/NavigationService` — frame-based. Resolves the active `Frame` through `IWindowShellProvider`, lazy-subscribes to `Frame.Navigated` on first access (so the shell can register after the service is constructed), reads `NavigationInfoAttribute` on each destination type, and dispatches the corresponding `NavigationTransitionInfo`.

Wires a gallery sample (`NavigationSamplePage`) into Shell + HomePage. The sample page implements `IWindowShell` and hosts a Frame; two demo pages (`NavigationDemoMainPage`, `NavigationDemoSettingsPage`) decorated with `[NavigationInfo("main", FromRight)]` and `[NavigationInfo("settings", FromBottom)]` navigate inside it. The status line shows `CurrentSection` updating.

Adds 9 unit tests covering the attribute (null-arg, defaults, custom transition, reflection discovery), the `Default → null` transition mapping, and the service's null-arg / no-shell error paths. The remaining `BuildTransitionInfo` branches can't be exercised headlessly — instantiating WinUI's `NavigationTransitionInfo` subclasses fails with "Ref assembly" in the test runner — and are documented in a comment.

### Out of scope (deferred)

- **Android back-gesture handling.** Apps wire it from their own activity lifecycle for now. Calling `GoBack()` works on every platform; the system-gesture binding is the part that needs platform-conditional code.

Closes #52

> **Stacked PR.** Targets `feature/issue-51-window-shell` (#70) — depends on `IWindowShellProvider`. Once #70 merges, retarget to `main`.

## Test plan

- [x] `dotnet build MZikmund.Toolkit.slnx -c Debug` succeeds.
- [x] Test exe reports 27/27 passed (18 prior + 9 new).
- [ ] Manually exercise the `Navigation` sample on Windows: click `Go to Main` (FromRight slide); click `Go to Settings` (FromBottom slide); status line updates `CurrentSection` to "main" / "settings"; click `Back` to confirm `CanGoBack` and back-navigation behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)