### PR TITLE
feat: Add ILocalizationService for runtime language switching

### DIFF
--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/HomePage.xaml
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/HomePage.xaml
@@ -46,6 +46,12 @@
           <Run Text="Localizer:" FontWeight="SemiBold" />
           <Run Text=" ILocalizer abstraction with static Localizer.Current accessor and a {Localize} XAML markup extension." />
         </TextBlock>
+
+        <TextBlock Style="{ThemeResource BodyTextBlockStyle}">
+          <Run Text="• " FontWeight="Bold" />
+          <Run Text="Localization Service:" FontWeight="SemiBold" />
+          <Run Text=" ILocalizationService manages active language at runtime — supported list, system detection, persistence, ApplicationLanguages.PrimaryLanguageOverride." />
+        </TextBlock>
         
         <TextBlock Style="{ThemeResource BodyTextBlockStyle}">
           <Run Text="• " FontWeight="Bold" />

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/LocalizationServiceSamplePage.xaml
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/LocalizationServiceSamplePage.xaml
@@ -1,0 +1,62 @@
+<Page x:Class="MZikmund.Toolkit.Sample.LocalizationServiceSamplePage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:local="using:MZikmund.Toolkit.Sample">
+
+  <ScrollViewer Padding="24">
+    <StackPanel Spacing="16" MaxWidth="800">
+      <TextBlock Text="ILocalizationService"
+                 Style="{ThemeResource TitleTextBlockStyle}" />
+
+      <TextBlock Text="LocalizationService manages the active app language at runtime: tracks current and supported languages, detects the system language for first launch, persists the choice through IPreferences, and pushes the change to ApplicationLanguages.PrimaryLanguageOverride. Apps subscribe to LanguageChanged to refresh views."
+                 TextWrapping="Wrap"
+                 Style="{ThemeResource BodyTextBlockStyle}" />
+
+      <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+              BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+              BorderThickness="1"
+              CornerRadius="8"
+              Padding="16">
+        <StackPanel Spacing="12">
+          <TextBlock Text="Live demo"
+                     Style="{ThemeResource SubtitleTextBlockStyle}" />
+
+          <TextBlock x:Name="SystemText" Style="{ThemeResource BodyTextBlockStyle}" />
+          <TextBlock x:Name="CurrentText" Style="{ThemeResource BodyStrongTextBlockStyle}" />
+
+          <ComboBox x:Name="LanguagePicker"
+                    Header="Language"
+                    SelectionChanged="LanguagePicker_SelectionChanged" />
+
+          <TextBlock x:Name="EventLog"
+                     FontFamily="Consolas"
+                     TextWrapping="Wrap"
+                     Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}" />
+        </StackPanel>
+      </Border>
+
+      <Border Background="{ThemeResource LayerFillColorDefaultBrush}"
+              BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+              BorderThickness="1"
+              CornerRadius="8"
+              Padding="16">
+        <StackPanel Spacing="8">
+          <TextBlock Text="Code Sample"
+                     Style="{ThemeResource SubtitleTextBlockStyle}" />
+
+          <TextBlock FontFamily="Consolas" TextWrapping="Wrap">
+            <Run>using MZikmund.Toolkit.WinUI.Services;</Run><LineBreak />
+            <LineBreak />
+            <Run>var localization = new LocalizationService(</Run><LineBreak />
+            <Run>    preferences,</Run><LineBreak />
+            <Run>    supportedLanguages: ["en-US", "cs-CZ", "de-DE"],</Run><LineBreak />
+            <Run>    fallbackLanguage: "en-US");</Run><LineBreak />
+            <LineBreak />
+            <Run>localization.LanguageChanged += (s, lang) =&gt; ReloadStrings();</Run><LineBreak />
+            <Run>localization.SetLanguage("cs-CZ");</Run>
+          </TextBlock>
+        </StackPanel>
+      </Border>
+    </StackPanel>
+  </ScrollViewer>
+</Page>

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/LocalizationServiceSamplePage.xaml.cs
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/LocalizationServiceSamplePage.xaml.cs
@@ -1,0 +1,89 @@
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using MZikmund.Toolkit.WinUI.Services;
+
+namespace MZikmund.Toolkit.Sample;
+
+public sealed partial class LocalizationServiceSamplePage : Page
+{
+    private readonly ILocalizationService _localization;
+
+    public LocalizationServiceSamplePage()
+    {
+        this.InitializeComponent();
+
+        var preferences = new InMemoryPreferences();
+        _localization = new LocalizationService(
+            preferences,
+            supportedLanguages: ["en-US", "cs-CZ", "de-DE", "fr-FR"],
+            fallbackLanguage: "en-US");
+        _localization.LanguageChanged += OnLanguageChanged;
+
+        SystemText.Text = $"System language: {_localization.GetSystemLanguage()}";
+        foreach (var language in _localization.SupportedLanguages)
+        {
+            LanguagePicker.Items.Add(language);
+        }
+        LanguagePicker.SelectedItem = _localization.CurrentLanguage;
+        UpdateCurrent();
+    }
+
+    private void LanguagePicker_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (LanguagePicker.SelectedItem is string language)
+        {
+            try
+            {
+                _localization.SetLanguage(language);
+            }
+            catch (ArgumentException ex)
+            {
+                EventLog.Text = ex.Message;
+            }
+        }
+    }
+
+    private void OnLanguageChanged(object? sender, string language)
+    {
+        EventLog.Text = $"LanguageChanged → {language}";
+        UpdateCurrent();
+    }
+
+    private void UpdateCurrent()
+    {
+        CurrentText.Text =
+            $"CurrentLanguage: {_localization.CurrentLanguage} (PrimaryLanguageOverride applied)";
+    }
+
+    private sealed class InMemoryPreferences : IPreferences
+    {
+        private readonly Dictionary<string, object?> _values = new();
+
+        public T Get<T>(string key, T defaultValue) =>
+            _values.TryGetValue(key, out var v) && v is T typed ? typed : defaultValue;
+
+        public bool TryGet<T>(string key, [MaybeNullWhen(false)] out T value)
+        {
+            if (_values.TryGetValue(key, out var v) && v is T typed)
+            {
+                value = typed;
+                return true;
+            }
+            value = default;
+            return false;
+        }
+
+        public void Set<T>(string key, T? value)
+        {
+            if (value is null) _values.Remove(key);
+            else _values[key] = value;
+        }
+
+        public T GetComplex<T>(string key, T defaultValue) => Get(key, defaultValue);
+
+        public bool TryGetComplex<T>(string key, [MaybeNullWhen(false)] out T value) => TryGet(key, out value);
+
+        public void SetComplex<T>(string key, T? value) => Set(key, value);
+    }
+}

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml
@@ -20,6 +20,7 @@
       <NavigationViewItem Content="ObservableCollection Merge" Tag="ObservableCollectionMerge" Icon="List" />
       <NavigationViewItemHeader Content="Localization" />
       <NavigationViewItem Content="Localizer" Tag="Localizer" Icon="Globe" />
+      <NavigationViewItem Content="Localization Service" Tag="LocalizationService" Icon="Globe" />
       <NavigationViewItemHeader Content="Infrastructure" />
       <NavigationViewItem Content="XamlRoot Provider" Tag="XamlRootProvider" Icon="Page" />
     </NavigationView.MenuItems>

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml.cs
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml.cs
@@ -31,6 +31,7 @@ public sealed partial class Shell : Page
                 "PackageVersion" => typeof(PackageVersionSamplePage),
                 "ObservableCollectionMerge" => typeof(ObservableCollectionMergeSamplePage),
                 "Localizer" => typeof(LocalizerSamplePage),
+                "LocalizationService" => typeof(LocalizationServiceSamplePage),
                 "XamlRootProvider" => typeof(XamlRootProviderSamplePage),
                 _ => null
             };

--- a/src/MZikmund.Toolkit.WinUI/Services/Localization/ILocalizationService.cs
+++ b/src/MZikmund.Toolkit.WinUI/Services/Localization/ILocalizationService.cs
@@ -1,0 +1,34 @@
+namespace MZikmund.Toolkit.WinUI.Services;
+
+/// <summary>
+/// Manages the active app language at runtime: tracks the current and supported
+/// languages, exposes the system language for first-launch detection, and applies
+/// language changes to the platform's resource lookup pipeline.
+/// </summary>
+/// <remarks>
+/// The service only manages <em>which</em> language is active; the actual translation
+/// lookup is performed by an <c>ILocalizer</c> implementation registered separately
+/// (typically backed by <c>IStringLocalizer</c>). Apps subscribe to
+/// <see cref="LanguageChanged"/> to refresh views when the language changes.
+/// </remarks>
+public interface ILocalizationService
+{
+    /// <summary>The currently active language tag (e.g. <c>"en-US"</c>, <c>"cs-CZ"</c>).</summary>
+    string CurrentLanguage { get; }
+
+    /// <summary>Languages the app ships translations for, in declaration order.</summary>
+    IReadOnlyList<string> SupportedLanguages { get; }
+
+    /// <summary>Raised after a successful language change.</summary>
+    event EventHandler<string>? LanguageChanged;
+
+    /// <summary>
+    /// Switches the active language. Persists the choice and applies it to
+    /// <c>Windows.Globalization.ApplicationLanguages.PrimaryLanguageOverride</c>.
+    /// </summary>
+    /// <exception cref="ArgumentException"><paramref name="language"/> is not in <see cref="SupportedLanguages"/>.</exception>
+    void SetLanguage(string language);
+
+    /// <summary>The OS-reported UI culture, e.g. <c>"cs-CZ"</c> on a Czech device.</summary>
+    string GetSystemLanguage();
+}

--- a/src/MZikmund.Toolkit.WinUI/Services/Localization/LocalizationService.cs
+++ b/src/MZikmund.Toolkit.WinUI/Services/Localization/LocalizationService.cs
@@ -1,0 +1,115 @@
+using System.Globalization;
+using Windows.Globalization;
+
+namespace MZikmund.Toolkit.WinUI.Services;
+
+/// <summary>
+/// Default <see cref="ILocalizationService"/>. Persists the user's language choice
+/// through <see cref="IPreferences"/> and applies it via
+/// <see cref="ApplicationLanguages.PrimaryLanguageOverride"/>.
+/// </summary>
+/// <remarks>
+/// On first launch (or when the persisted language is no longer supported), the
+/// constructor falls through this preference order:
+/// <list type="number">
+///   <item><description>The persisted choice, if it's still in <see cref="SupportedLanguages"/>.</description></item>
+///   <item><description>The OS UI culture, if it's in <see cref="SupportedLanguages"/>.</description></item>
+///   <item><description>The explicit <c>fallbackLanguage</c> constructor argument.</description></item>
+///   <item><description>The first entry of <see cref="SupportedLanguages"/>.</description></item>
+/// </list>
+/// </remarks>
+public class LocalizationService : ILocalizationService
+{
+    private const string LanguagePreferenceKey = "MZikmund.Toolkit.Language";
+
+    private readonly IPreferences _preferences;
+    private readonly List<string> _supported;
+    private string _currentLanguage;
+
+    /// <summary>Initializes a new instance.</summary>
+    /// <param name="preferences">Preferences service for persisting the choice.</param>
+    /// <param name="supportedLanguages">Languages the app ships translations for.</param>
+    /// <param name="fallbackLanguage">Used when no persisted / system language matches.</param>
+    public LocalizationService(
+        IPreferences preferences,
+        IEnumerable<string> supportedLanguages,
+        string? fallbackLanguage = null)
+    {
+        ArgumentNullException.ThrowIfNull(preferences);
+        ArgumentNullException.ThrowIfNull(supportedLanguages);
+
+        _preferences = preferences;
+        _supported = supportedLanguages.ToList();
+        if (_supported.Count == 0)
+        {
+            throw new ArgumentException("Supported languages list cannot be empty.", nameof(supportedLanguages));
+        }
+
+        _currentLanguage = ResolveInitialLanguage(fallbackLanguage);
+        ApplyToPlatform(_currentLanguage);
+    }
+
+    /// <inheritdoc />
+    public string CurrentLanguage => _currentLanguage;
+
+    /// <inheritdoc />
+    public IReadOnlyList<string> SupportedLanguages => _supported;
+
+    /// <inheritdoc />
+    public event EventHandler<string>? LanguageChanged;
+
+    /// <inheritdoc />
+    public void SetLanguage(string language)
+    {
+        ArgumentNullException.ThrowIfNull(language);
+        if (!_supported.Contains(language))
+        {
+            throw new ArgumentException(
+                $"Language '{language}' is not in SupportedLanguages.", nameof(language));
+        }
+
+        if (_currentLanguage == language)
+        {
+            return;
+        }
+
+        _currentLanguage = language;
+        _preferences.Set(LanguagePreferenceKey, language);
+        ApplyToPlatform(language);
+        LanguageChanged?.Invoke(this, language);
+    }
+
+    /// <inheritdoc />
+    public string GetSystemLanguage() => CultureInfo.CurrentUICulture.Name;
+
+    private string ResolveInitialLanguage(string? fallbackLanguage)
+    {
+        var saved = _preferences.Get(LanguagePreferenceKey, string.Empty);
+        if (!string.IsNullOrEmpty(saved) && _supported.Contains(saved))
+        {
+            return saved;
+        }
+
+        var system = GetSystemLanguage();
+        if (_supported.Contains(system))
+        {
+            return system;
+        }
+
+        if (!string.IsNullOrEmpty(fallbackLanguage) && _supported.Contains(fallbackLanguage))
+        {
+            return fallbackLanguage!;
+        }
+
+        return _supported[0];
+    }
+
+    /// <summary>
+    /// Pushes the language change to the platform. Default implementation sets
+    /// <see cref="ApplicationLanguages.PrimaryLanguageOverride"/>. Tests override
+    /// to avoid the platform call (the Windows Runtime type isn't initializable
+    /// in a console test host).
+    /// </summary>
+    protected virtual void ApplyToPlatform(string language) =>
+        ApplicationLanguages.PrimaryLanguageOverride = language;
+}

--- a/tests/MZikmund.Toolkit.WinUI.Tests/LocalizationServiceTests.cs
+++ b/tests/MZikmund.Toolkit.WinUI.Tests/LocalizationServiceTests.cs
@@ -1,0 +1,171 @@
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MZikmund.Toolkit.WinUI.Services;
+
+namespace MZikmund.Toolkit.WinUI.Tests;
+
+[TestClass]
+public class LocalizationServiceTests
+{
+    [TestMethod]
+    public void Ctor_NullPreferences_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            new TestLocalizationService(null!, ["en-US"]));
+    }
+
+    [TestMethod]
+    public void Ctor_NullSupportedLanguages_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            new TestLocalizationService(new InMemoryPreferences(), null!));
+    }
+
+    [TestMethod]
+    public void Ctor_EmptySupportedLanguages_Throws()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            new TestLocalizationService(new InMemoryPreferences(), Array.Empty<string>()));
+    }
+
+    [TestMethod]
+    public void Ctor_PicksUpPersistedLanguage_WhenSupported()
+    {
+        var prefs = new InMemoryPreferences();
+        prefs.Set("MZikmund.Toolkit.Language", "cs-CZ");
+
+        var sut = new TestLocalizationService(prefs, ["en-US", "cs-CZ", "de-DE"]);
+
+        Assert.AreEqual("cs-CZ", sut.CurrentLanguage);
+    }
+
+    [TestMethod]
+    public void Ctor_PersistedLanguageNotSupported_FallsBackToFallbackArgument()
+    {
+        var prefs = new InMemoryPreferences();
+        prefs.Set("MZikmund.Toolkit.Language", "ja-JP"); // not in list
+
+        var sut = new TestLocalizationService(
+            prefs,
+            ["en-US", "de-DE"],
+            fallbackLanguage: "en-US");
+
+        Assert.AreEqual("en-US", sut.CurrentLanguage);
+    }
+
+    [TestMethod]
+    public void Ctor_NoPersisted_NoSystemMatch_NoFallback_UsesFirstSupported()
+    {
+        var sut = new TestLocalizationService(new InMemoryPreferences(), ["fi-FI", "is-IS"]);
+
+        Assert.AreEqual("fi-FI", sut.CurrentLanguage);
+    }
+
+    [TestMethod]
+    public void SetLanguage_UnsupportedLanguage_Throws()
+    {
+        var sut = new TestLocalizationService(new InMemoryPreferences(), ["en-US", "cs-CZ"]);
+
+        Assert.Throws<ArgumentException>(() => sut.SetLanguage("ja-JP"));
+    }
+
+    [TestMethod]
+    public void SetLanguage_NullLanguage_Throws()
+    {
+        var sut = new TestLocalizationService(new InMemoryPreferences(), ["en-US", "cs-CZ"]);
+
+        Assert.Throws<ArgumentNullException>(() => sut.SetLanguage(null!));
+    }
+
+    [TestMethod]
+    public void SetLanguage_NewLanguage_PersistsAndRaisesEvent()
+    {
+        var prefs = new InMemoryPreferences();
+        var sut = new TestLocalizationService(prefs, ["en-US", "cs-CZ", "de-DE"], fallbackLanguage: "en-US");
+        var captured = new List<string>();
+        sut.LanguageChanged += (_, lang) => captured.Add(lang);
+
+        sut.SetLanguage("cs-CZ");
+
+        Assert.AreEqual("cs-CZ", sut.CurrentLanguage);
+        CollectionAssert.AreEqual(new[] { "cs-CZ" }, captured);
+        Assert.AreEqual("cs-CZ", prefs.Get("MZikmund.Toolkit.Language", string.Empty));
+    }
+
+    [TestMethod]
+    public void SetLanguage_SameLanguage_DoesNotRaiseEvent()
+    {
+        var sut = new TestLocalizationService(new InMemoryPreferences(), ["en-US", "cs-CZ"], fallbackLanguage: "en-US");
+        var fired = 0;
+        sut.LanguageChanged += (_, _) => fired++;
+
+        sut.SetLanguage(sut.CurrentLanguage);
+
+        Assert.AreEqual(0, fired);
+    }
+
+    [TestMethod]
+    public void SupportedLanguages_PreservesOrder()
+    {
+        var sut = new TestLocalizationService(
+            new InMemoryPreferences(),
+            ["en-US", "cs-CZ", "de-DE", "fr-FR"]);
+
+        CollectionAssert.AreEqual(
+            new[] { "en-US", "cs-CZ", "de-DE", "fr-FR" },
+            sut.SupportedLanguages.ToList());
+    }
+
+    [TestMethod]
+    public void GetSystemLanguage_ReturnsCurrentUICultureName()
+    {
+        var sut = new TestLocalizationService(new InMemoryPreferences(), ["en-US"]);
+
+        Assert.AreEqual(System.Globalization.CultureInfo.CurrentUICulture.Name, sut.GetSystemLanguage());
+    }
+
+    private sealed class TestLocalizationService : LocalizationService
+    {
+        public TestLocalizationService(IPreferences preferences, IEnumerable<string> supportedLanguages, string? fallbackLanguage = null)
+            : base(preferences, supportedLanguages, fallbackLanguage)
+        {
+        }
+
+        protected override void ApplyToPlatform(string language)
+        {
+            // No-op: ApplicationLanguages.PrimaryLanguageOverride is unavailable in
+            // the headless test host (the Windows Runtime initializer NRE's).
+        }
+    }
+
+    private sealed class InMemoryPreferences : IPreferences
+    {
+        private readonly Dictionary<string, object?> _values = new();
+
+        public T Get<T>(string key, T defaultValue) =>
+            _values.TryGetValue(key, out var v) && v is T typed ? typed : defaultValue;
+
+        public bool TryGet<T>(string key, [MaybeNullWhen(false)] out T value)
+        {
+            if (_values.TryGetValue(key, out var v) && v is T typed)
+            {
+                value = typed;
+                return true;
+            }
+            value = default;
+            return false;
+        }
+
+        public void Set<T>(string key, T? value)
+        {
+            if (value is null) _values.Remove(key);
+            else _values[key] = value;
+        }
+
+        public T GetComplex<T>(string key, T defaultValue) => Get(key, defaultValue);
+
+        public bool TryGetComplex<T>(string key, [MaybeNullWhen(false)] out T value) => TryGet(key, out value);
+
+        public void SetComplex<T>(string key, T? value) => Set(key, value);
+    }
+}


### PR DESCRIPTION
## Summary

Adds the dynamic localization service from #39 under `MZikmund.Toolkit.WinUI.Services`:

- **`ILocalizationService`** — `CurrentLanguage`, `SupportedLanguages`, `GetSystemLanguage`, `SetLanguage`, `LanguageChanged` event.
- **`LocalizationService`** — persists the choice through `IPreferences` and applies it via `Windows.Globalization.ApplicationLanguages.PrimaryLanguageOverride`. First-launch language resolution walks the preference order:
  1. Persisted choice (if still in `SupportedLanguages`).
  2. OS UI culture (`CultureInfo.CurrentUICulture.Name`) if it's in the list.
  3. Constructor `fallbackLanguage` argument.
  4. First entry of `SupportedLanguages`.
- `ApplyToPlatform` is a **protected virtual hook** so tests can subclass and skip the WinRT call (`ApplicationLanguages` NREs in a headless console host).

The service deliberately doesn't perform the actual translation lookup — that's `ILocalizer`'s job (already promoted in #47). Apps register both: `ILocalizer` for `GetString(key)`, `ILocalizationService` for "which language is active".

Wires a gallery sample (`LocalizationServiceSamplePage`) into Shell + HomePage with a 4-language supported list, a system-language readout, a language picker, and a live event log.

Adds 12 unit tests covering null-arg and empty-list constructor guards, persisted-language pickup, fallback resolution chain, unsupported / null `SetLanguage` throws, the persist + raise + same-language no-op behavior, supported-list ordering, and `GetSystemLanguage`.

Closes #39

> **Stacked PR.** Targets `feature/issue-47-localizer` (#62) for thematic consistency with the localization stack — `ILocalizer` from #47 is the pair this service complements. No code dependency; once #62 merges, this can retarget to `main`.

## Test plan

- [x] `dotnet build MZikmund.Toolkit.slnx -c Debug` succeeds.
- [x] Test exe reports 29/29 passed (17 prior + 12 new).
- [ ] Manually exercise the `Localization Service` sample on Windows: pick each language in the dropdown and confirm the `LanguageChanged` event log updates and `CurrentLanguage` reflects the new choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)