### PR TITLE
feat: Add ColorPickerDialog wrapping WinUI ColorPicker

### DIFF
--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/ColorPickerDialogSamplePage.xaml
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/ColorPickerDialogSamplePage.xaml
@@ -1,0 +1,70 @@
+<Page x:Class="MZikmund.Toolkit.Sample.ColorPickerDialogSamplePage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:local="using:MZikmund.Toolkit.Sample">
+
+  <ScrollViewer Padding="24">
+    <StackPanel Spacing="16" MaxWidth="800">
+      <TextBlock Text="ColorPickerDialog"
+                 Style="{ThemeResource TitleTextBlockStyle}" />
+
+      <TextBlock Text="ColorPickerDialog wraps the WinUI ColorPicker in a ContentDialog with OK / Cancel buttons. Static PickAsync(xamlRoot, initialColor) returns the chosen Color or null on cancel."
+                 TextWrapping="Wrap"
+                 Style="{ThemeResource BodyTextBlockStyle}" />
+
+      <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+              BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+              BorderThickness="1"
+              CornerRadius="8"
+              Padding="16">
+        <StackPanel Spacing="12">
+          <TextBlock Text="Live demo"
+                     Style="{ThemeResource SubtitleTextBlockStyle}" />
+
+          <StackPanel Orientation="Horizontal" Spacing="12">
+            <Button Content="Pick a color" Click="Pick_Click" Style="{ThemeResource AccentButtonStyle}" />
+
+            <Border x:Name="SwatchBorder"
+                    Width="48"
+                    Height="48"
+                    CornerRadius="4"
+                    BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                    BorderThickness="1">
+              <Border.Background>
+                <SolidColorBrush x:Name="SwatchBrush" Color="DodgerBlue" />
+              </Border.Background>
+            </Border>
+
+            <TextBlock x:Name="SwatchText"
+                       VerticalAlignment="Center"
+                       FontFamily="Consolas"
+                       Text="#FF1E90FF" />
+          </StackPanel>
+
+          <TextBlock x:Name="StatusText" Style="{ThemeResource BodyTextBlockStyle}" />
+        </StackPanel>
+      </Border>
+
+      <Border Background="{ThemeResource LayerFillColorDefaultBrush}"
+              BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+              BorderThickness="1"
+              CornerRadius="8"
+              Padding="16">
+        <StackPanel Spacing="8">
+          <TextBlock Text="Code Sample"
+                     Style="{ThemeResource SubtitleTextBlockStyle}" />
+
+          <TextBlock FontFamily="Consolas" TextWrapping="Wrap">
+            <Run>using MZikmund.Toolkit.WinUI.Dialogs;</Run><LineBreak />
+            <LineBreak />
+            <Run>var picked = await ColorPickerDialog.PickAsync(this.XamlRoot, Colors.DodgerBlue);</Run><LineBreak />
+            <Run>if (picked is { } color)</Run><LineBreak />
+            <Run>{</Run><LineBreak />
+            <Run>    SwatchBrush.Color = color;</Run><LineBreak />
+            <Run>}</Run>
+          </TextBlock>
+        </StackPanel>
+      </Border>
+    </StackPanel>
+  </ScrollViewer>
+</Page>

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/ColorPickerDialogSamplePage.xaml.cs
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/ColorPickerDialogSamplePage.xaml.cs
@@ -1,0 +1,28 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using MZikmund.Toolkit.WinUI.Dialogs;
+
+namespace MZikmund.Toolkit.Sample;
+
+public sealed partial class ColorPickerDialogSamplePage : Page
+{
+    public ColorPickerDialogSamplePage()
+    {
+        this.InitializeComponent();
+    }
+
+    private async void Pick_Click(object sender, RoutedEventArgs e)
+    {
+        var picked = await ColorPickerDialog.PickAsync(this.XamlRoot, SwatchBrush.Color);
+        if (picked is { } color)
+        {
+            SwatchBrush.Color = color;
+            SwatchText.Text = $"#{color.A:X2}{color.R:X2}{color.G:X2}{color.B:X2}";
+            StatusText.Text = "Color picked.";
+        }
+        else
+        {
+            StatusText.Text = "Picker cancelled — color unchanged.";
+        }
+    }
+}

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/HomePage.xaml
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/HomePage.xaml
@@ -28,6 +28,12 @@
           <Run Text="Dialog Coordinator:" FontWeight="SemiBold" />
           <Run Text=" Coordinates ContentDialog display to ensure only one dialog is shown at a time." />
         </TextBlock>
+
+        <TextBlock Style="{ThemeResource BodyTextBlockStyle}">
+          <Run Text="• " FontWeight="Bold" />
+          <Run Text="Color Picker Dialog:" FontWeight="SemiBold" />
+          <Run Text=" ColorPickerDialog wraps the WinUI ColorPicker in a ContentDialog with a one-call PickAsync helper." />
+        </TextBlock>
         
         <TextBlock Style="{ThemeResource BodyTextBlockStyle}">
           <Run Text="• " FontWeight="Bold" />

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml
@@ -15,6 +15,7 @@
       <NavigationViewItemHeader Content="Services" />
       <NavigationViewItem Content="Preferences" Tag="Preferences" Icon="Setting" />
       <NavigationViewItem Content="Dialog Coordinator" Tag="DialogCoordinator" Icon="Message" />
+      <NavigationViewItem Content="Color Picker Dialog" Tag="ColorPickerDialog" Icon="Edit" />
       <NavigationViewItemHeader Content="Extensions" />
       <NavigationViewItem Content="Package Version" Tag="PackageVersion" Icon="Document" />
       <NavigationViewItem Content="ObservableCollection Merge" Tag="ObservableCollectionMerge" Icon="List" />

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml.cs
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml.cs
@@ -28,6 +28,7 @@ public sealed partial class Shell : Page
                 "Home" => typeof(HomePage),
                 "Preferences" => typeof(PreferencesSamplePage),
                 "DialogCoordinator" => typeof(DialogCoordinatorSamplePage),
+                "ColorPickerDialog" => typeof(ColorPickerDialogSamplePage),
                 "PackageVersion" => typeof(PackageVersionSamplePage),
                 "ObservableCollectionMerge" => typeof(ObservableCollectionMergeSamplePage),
                 "XamlRootProvider" => typeof(XamlRootProviderSamplePage),

--- a/src/MZikmund.Toolkit.WinUI/Dialogs/ColorPickerDialog.cs
+++ b/src/MZikmund.Toolkit.WinUI/Dialogs/ColorPickerDialog.cs
@@ -1,0 +1,90 @@
+using Microsoft.UI;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Windows.UI;
+
+namespace MZikmund.Toolkit.WinUI.Dialogs;
+
+/// <summary>
+/// A simple <see cref="ContentDialog"/> wrapping the WinUI <see cref="ColorPicker"/>
+/// control. Use the static <see cref="PickAsync(XamlRoot, Color, ColorPickerDialogStrings?)"/>
+/// helper for one-call usage; the dialog itself can also be constructed and shown manually
+/// to integrate with <c>IDialogCoordinator</c>.
+/// </summary>
+public sealed partial class ColorPickerDialog : ContentDialog
+{
+    /// <summary>The color picker control hosted inside the dialog.</summary>
+    public ColorPicker ColorPicker { get; }
+
+    /// <summary>
+    /// The currently chosen color. Bound two-way to <see cref="ColorPicker.Color"/>.
+    /// </summary>
+    public Color SelectedColor
+    {
+        get => ColorPicker.Color;
+        set => ColorPicker.Color = value;
+    }
+
+    /// <summary>Initializes a new instance with default labels.</summary>
+    public ColorPickerDialog() : this(strings: null)
+    {
+    }
+
+    /// <summary>Initializes a new instance with optional custom labels.</summary>
+    public ColorPickerDialog(ColorPickerDialogStrings? strings)
+    {
+        var s = strings ?? new ColorPickerDialogStrings();
+
+        ColorPicker = new ColorPicker
+        {
+            IsAlphaEnabled = true,
+            ColorSpectrumShape = ColorSpectrumShape.Box,
+            IsMoreButtonVisible = true,
+        };
+
+        Title = s.Title;
+        PrimaryButtonText = s.OkButtonText;
+        CloseButtonText = s.CancelButtonText;
+        DefaultButton = ContentDialogButton.Primary;
+        Content = ColorPicker;
+    }
+
+    /// <summary>
+    /// Convenience: builds, shows, and returns the user's chosen color.
+    /// </summary>
+    /// <param name="xamlRoot">XAML root to anchor the dialog to.</param>
+    /// <param name="initialColor">Color to seed the picker with.</param>
+    /// <param name="strings">Optional override for the title and button labels.</param>
+    /// <returns>The chosen color, or <see langword="null"/> if the user cancelled.</returns>
+    public static async Task<Color?> PickAsync(
+        XamlRoot xamlRoot,
+        Color initialColor,
+        ColorPickerDialogStrings? strings = null)
+    {
+        ArgumentNullException.ThrowIfNull(xamlRoot);
+
+        var dialog = new ColorPickerDialog(strings)
+        {
+            XamlRoot = xamlRoot,
+            SelectedColor = initialColor,
+        };
+
+        var result = await dialog.ShowAsync();
+        return result == ContentDialogResult.Primary
+            ? dialog.SelectedColor
+            : (Color?)null;
+    }
+}
+
+/// <summary>Localizable labels used by <see cref="ColorPickerDialog"/>.</summary>
+public sealed class ColorPickerDialogStrings
+{
+    /// <summary>Dialog title. Defaults to <c>"Choose a color"</c>.</summary>
+    public string Title { get; init; } = "Choose a color";
+
+    /// <summary>Affirmative button text. Defaults to <c>"OK"</c>.</summary>
+    public string OkButtonText { get; init; } = "OK";
+
+    /// <summary>Cancel button text. Defaults to <c>"Cancel"</c>.</summary>
+    public string CancelButtonText { get; init; } = "Cancel";
+}

--- a/tests/MZikmund.Toolkit.WinUI.Tests/ColorPickerDialogTests.cs
+++ b/tests/MZikmund.Toolkit.WinUI.Tests/ColorPickerDialogTests.cs
@@ -1,0 +1,36 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MZikmund.Toolkit.WinUI.Dialogs;
+
+namespace MZikmund.Toolkit.WinUI.Tests;
+
+[TestClass]
+public class ColorPickerDialogStringsTests
+{
+    // ColorPickerDialog itself derives from ContentDialog and can't be instantiated
+    // headlessly. The strings POCO is the testable portion of the surface.
+
+    [TestMethod]
+    public void Defaults_AreEnglish()
+    {
+        var s = new ColorPickerDialogStrings();
+
+        Assert.AreEqual("Choose a color", s.Title);
+        Assert.AreEqual("OK", s.OkButtonText);
+        Assert.AreEqual("Cancel", s.CancelButtonText);
+    }
+
+    [TestMethod]
+    public void InitOnly_AppliesCustomValues()
+    {
+        var s = new ColorPickerDialogStrings
+        {
+            Title = "Vyberte barvu",
+            OkButtonText = "Potvrdit",
+            CancelButtonText = "Zrušit",
+        };
+
+        Assert.AreEqual("Vyberte barvu", s.Title);
+        Assert.AreEqual("Potvrdit", s.OkButtonText);
+        Assert.AreEqual("Zrušit", s.CancelButtonText);
+    }
+}


### PR DESCRIPTION
## Summary

Adds `ColorPickerDialog` in `MZikmund.Toolkit.WinUI.Dialogs` — a `ContentDialog` that hosts a WinUI `ColorPicker` with OK / Cancel buttons and surfaces the selection through a `SelectedColor` property.

A one-call static helper is provided for the common case:

```csharp
var picked = await ColorPickerDialog.PickAsync(this.XamlRoot, Colors.DodgerBlue);
if (picked is { } color)
{
    SwatchBrush.Color = color;
}
```

Title and button labels are localizable through an optional `ColorPickerDialogStrings` argument (defaults: `"Choose a color"`, `"OK"`, `"Cancel"`). The picker has `IsAlphaEnabled = true` and `IsMoreButtonVisible = true` so users can dial in precise ARGB / hex / RGB.

> The issue body was empty; this PR ships the most direct interpretation of the title — a `ContentDialog` that wraps `ColorPicker`. If a different shape is wanted, a follow-up can adjust.

Wires a gallery sample (`ColorPickerDialogSamplePage`) into Shell + HomePage with a swatch + hex readout that updates after the user picks a color.

Adds 2 unit tests covering `ColorPickerDialogStrings` defaults and init-only behavior. The dialog itself derives from `ContentDialog` and can't be instantiated headlessly (the WinUI `FrameworkElement` initializer needs a XAML runtime), so the picker behavior is verified through the sample.

Closes #13

> Stacked on top of #56 (the `MergeWith` PR). Rebase on `main` once #56 merges.

## Test plan

- [x] `dotnet build MZikmund.Toolkit.slnx -c Debug` succeeds (all platforms green, including iOS / macCatalyst).
- [x] Test exe reports 16/16 passed (14 prior + 2 new).
- [ ] Manually exercise the `Color Picker Dialog` sample on Windows: click `Pick a color`, choose a new color, click `OK` — confirm the swatch and hex readout update; click `Pick a color` again, change the value, click `Cancel` — confirm the swatch stays at the previous value and the status reads "cancelled".

🤖 Generated with [Claude Code](https://claude.com/claude-code)