### PR TITLE
feat: Add IAuditableEntity + ISoftDeletable interfaces

### DIFF
--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/AuditableEntitySamplePage.xaml
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/AuditableEntitySamplePage.xaml
@@ -1,0 +1,70 @@
+<Page x:Class="MZikmund.Toolkit.Sample.AuditableEntitySamplePage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:local="using:MZikmund.Toolkit.Sample">
+
+  <ScrollViewer Padding="24">
+    <StackPanel Spacing="16" MaxWidth="800">
+      <TextBlock Text="IAuditableEntity + ISoftDeletable"
+                 Style="{ThemeResource TitleTextBlockStyle}" />
+
+      <TextBlock Text="Two marker interfaces and their stamping helpers. IAuditableEntity records CreatedAt / LastModifiedAt. ISoftDeletable records IsDeleted / DeletedAt. The toolkit ships only the markers + extension helpers — apps wire them into their DbContext.SaveChangesAsync override and OnModelCreating query filter (snippets in the XML doc comments)."
+                 TextWrapping="Wrap"
+                 Style="{ThemeResource BodyTextBlockStyle}" />
+
+      <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+              BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+              BorderThickness="1"
+              CornerRadius="8"
+              Padding="16">
+        <StackPanel Spacing="12">
+          <TextBlock Text="Live demo"
+                     Style="{ThemeResource SubtitleTextBlockStyle}" />
+
+          <TextBox x:Name="NameInput" Header="Name" Text="Sample reminder" />
+
+          <StackPanel Orientation="Horizontal" Spacing="8">
+            <Button Content="Create" Click="Create_Click" Style="{ThemeResource AccentButtonStyle}" />
+            <Button Content="Update" Click="Update_Click" />
+            <Button Content="Delete (soft)" Click="Delete_Click" />
+            <Button Content="Restore" Click="Restore_Click" />
+          </StackPanel>
+
+          <TextBlock x:Name="StateText"
+                     FontFamily="Consolas"
+                     TextWrapping="Wrap"
+                     Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}" />
+        </StackPanel>
+      </Border>
+
+      <Border Background="{ThemeResource LayerFillColorDefaultBrush}"
+              BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+              BorderThickness="1"
+              CornerRadius="8"
+              Padding="16">
+        <StackPanel Spacing="8">
+          <TextBlock Text="Code Sample"
+                     Style="{ThemeResource SubtitleTextBlockStyle}" />
+
+          <TextBlock FontFamily="Consolas" TextWrapping="Wrap">
+            <Run>using MZikmund.Toolkit.WinUI.Data;</Run><LineBreak />
+            <LineBreak />
+            <Run>public class Reminder : IAuditableEntity, ISoftDeletable</Run><LineBreak />
+            <Run>{</Run><LineBreak />
+            <Run>    public string Name { get; set; } = "";</Run><LineBreak />
+            <Run>    public DateTime CreatedAt { get; set; }</Run><LineBreak />
+            <Run>    public DateTime LastModifiedAt { get; set; }</Run><LineBreak />
+            <Run>    public bool IsDeleted { get; set; }</Run><LineBreak />
+            <Run>    public DateTime? DeletedAt { get; set; }</Run><LineBreak />
+            <Run>}</Run><LineBreak />
+            <LineBreak />
+            <Run>reminder.StampForCreate();</Run><LineBreak />
+            <Run>reminder.StampForUpdate();</Run><LineBreak />
+            <Run>reminder.MarkDeleted();</Run><LineBreak />
+            <Run>reminder.Restore();</Run>
+          </TextBlock>
+        </StackPanel>
+      </Border>
+    </StackPanel>
+  </ScrollViewer>
+</Page>

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/AuditableEntitySamplePage.xaml.cs
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/AuditableEntitySamplePage.xaml.cs
@@ -1,0 +1,86 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using MZikmund.Toolkit.WinUI.Data;
+
+namespace MZikmund.Toolkit.Sample;
+
+public sealed partial class AuditableEntitySamplePage : Page
+{
+    private Reminder? _reminder;
+
+    public AuditableEntitySamplePage()
+    {
+        this.InitializeComponent();
+        UpdateState();
+    }
+
+    private void Create_Click(object sender, RoutedEventArgs e)
+    {
+        _reminder = new Reminder { Name = NameInput.Text };
+        _reminder.StampForCreate();
+        UpdateState();
+    }
+
+    private void Update_Click(object sender, RoutedEventArgs e)
+    {
+        if (_reminder is null)
+        {
+            StateText.Text = "Create the entity first.";
+            return;
+        }
+        _reminder.Name = NameInput.Text;
+        _reminder.StampForUpdate();
+        UpdateState();
+    }
+
+    private void Delete_Click(object sender, RoutedEventArgs e)
+    {
+        if (_reminder is null)
+        {
+            StateText.Text = "Create the entity first.";
+            return;
+        }
+        _reminder.MarkDeleted();
+        UpdateState();
+    }
+
+    private void Restore_Click(object sender, RoutedEventArgs e)
+    {
+        if (_reminder is null)
+        {
+            StateText.Text = "Create the entity first.";
+            return;
+        }
+        _reminder.Restore();
+        UpdateState();
+    }
+
+    private void UpdateState()
+    {
+        if (_reminder is null)
+        {
+            StateText.Text = "(no entity yet)";
+            return;
+        }
+
+        StateText.Text =
+            $"Name: {_reminder.Name}\n" +
+            $"CreatedAt: {_reminder.CreatedAt:O}\n" +
+            $"LastModifiedAt: {_reminder.LastModifiedAt:O}\n" +
+            $"IsDeleted: {_reminder.IsDeleted}\n" +
+            $"DeletedAt: {(_reminder.DeletedAt is { } d ? d.ToString("O") : "(null)")}";
+    }
+
+    private sealed class Reminder : IAuditableEntity, ISoftDeletable
+    {
+        public string Name { get; set; } = string.Empty;
+
+        public DateTime CreatedAt { get; set; }
+
+        public DateTime LastModifiedAt { get; set; }
+
+        public bool IsDeleted { get; set; }
+
+        public DateTime? DeletedAt { get; set; }
+    }
+}

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/HomePage.xaml
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/HomePage.xaml
@@ -40,6 +40,12 @@
           <Run Text="ObservableCollection Merge:" FontWeight="SemiBold" />
           <Run Text=" MergeWith extension that synchronizes an ObservableCollection with a source list using minimal Insert/RemoveAt/Move operations." />
         </TextBlock>
+
+        <TextBlock Style="{ThemeResource BodyTextBlockStyle}">
+          <Run Text="• " FontWeight="Bold" />
+          <Run Text="Auditable / Soft-Delete:" FontWeight="SemiBold" />
+          <Run Text=" IAuditableEntity + ISoftDeletable marker interfaces with stamping helpers — wires into your DbContext.SaveChangesAsync." />
+        </TextBlock>
         
         <TextBlock Style="{ThemeResource BodyTextBlockStyle}">
           <Run Text="• " FontWeight="Bold" />

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml
@@ -18,6 +18,8 @@
       <NavigationViewItemHeader Content="Extensions" />
       <NavigationViewItem Content="Package Version" Tag="PackageVersion" Icon="Document" />
       <NavigationViewItem Content="ObservableCollection Merge" Tag="ObservableCollectionMerge" Icon="List" />
+      <NavigationViewItemHeader Content="Data" />
+      <NavigationViewItem Content="Auditable / Soft-Delete" Tag="AuditableEntity" Icon="Save" />
       <NavigationViewItemHeader Content="Infrastructure" />
       <NavigationViewItem Content="XamlRoot Provider" Tag="XamlRootProvider" Icon="Page" />
     </NavigationView.MenuItems>

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml.cs
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml.cs
@@ -30,6 +30,7 @@ public sealed partial class Shell : Page
                 "DialogCoordinator" => typeof(DialogCoordinatorSamplePage),
                 "PackageVersion" => typeof(PackageVersionSamplePage),
                 "ObservableCollectionMerge" => typeof(ObservableCollectionMergeSamplePage),
+                "AuditableEntity" => typeof(AuditableEntitySamplePage),
                 "XamlRootProvider" => typeof(XamlRootProviderSamplePage),
                 _ => null
             };

--- a/src/MZikmund.Toolkit.WinUI/Data/AuditableEntityExtensions.cs
+++ b/src/MZikmund.Toolkit.WinUI/Data/AuditableEntityExtensions.cs
@@ -1,0 +1,33 @@
+namespace MZikmund.Toolkit.WinUI.Data;
+
+/// <summary>
+/// Helpers for stamping audit fields on <see cref="IAuditableEntity"/> instances.
+/// Apps wire these into their DbContext save pipeline (or any other persistence layer).
+/// </summary>
+public static class AuditableEntityExtensions
+{
+    /// <summary>
+    /// Sets <see cref="IAuditableEntity.CreatedAt"/> and <see cref="IAuditableEntity.LastModifiedAt"/>
+    /// to the same timestamp. Use on freshly-added entities.
+    /// </summary>
+    /// <param name="entity">Entity to stamp.</param>
+    /// <param name="at">Optional timestamp; defaults to <see cref="DateTime.UtcNow"/>.</param>
+    public static void StampForCreate(this IAuditableEntity entity, DateTime? at = null)
+    {
+        ArgumentNullException.ThrowIfNull(entity);
+        var now = at ?? DateTime.UtcNow;
+        entity.CreatedAt = now;
+        entity.LastModifiedAt = now;
+    }
+
+    /// <summary>
+    /// Sets <see cref="IAuditableEntity.LastModifiedAt"/>. Use on entities being updated.
+    /// </summary>
+    /// <param name="entity">Entity to stamp.</param>
+    /// <param name="at">Optional timestamp; defaults to <see cref="DateTime.UtcNow"/>.</param>
+    public static void StampForUpdate(this IAuditableEntity entity, DateTime? at = null)
+    {
+        ArgumentNullException.ThrowIfNull(entity);
+        entity.LastModifiedAt = at ?? DateTime.UtcNow;
+    }
+}

--- a/src/MZikmund.Toolkit.WinUI/Data/IAuditableEntity.cs
+++ b/src/MZikmund.Toolkit.WinUI/Data/IAuditableEntity.cs
@@ -1,0 +1,32 @@
+namespace MZikmund.Toolkit.WinUI.Data;
+
+/// <summary>
+/// Marks an entity that records when it was created and last modified.
+/// </summary>
+/// <remarks>
+/// Apps using EF Core typically stamp these in a <c>DbContext.SaveChangesAsync</c>
+/// override:
+/// <code>
+/// public override async Task&lt;int&gt; SaveChangesAsync(CancellationToken ct = default)
+/// {
+///     var now = DateTime.UtcNow;
+///     foreach (var entry in ChangeTracker.Entries&lt;IAuditableEntity&gt;())
+///     {
+///         if (entry.State == EntityState.Added) entry.Entity.StampForCreate(now);
+///         else if (entry.State == EntityState.Modified) entry.Entity.StampForUpdate(now);
+///     }
+///     return await base.SaveChangesAsync(ct);
+/// }
+/// </code>
+/// The toolkit ships only the marker interface and the
+/// <see cref="AuditableEntityExtensions"/> stamping helpers — the toolkit itself
+/// doesn't take an EF Core dependency.
+/// </remarks>
+public interface IAuditableEntity
+{
+    /// <summary>UTC timestamp recorded when the entity was first persisted.</summary>
+    DateTime CreatedAt { get; set; }
+
+    /// <summary>UTC timestamp recorded on the most recent update.</summary>
+    DateTime LastModifiedAt { get; set; }
+}

--- a/src/MZikmund.Toolkit.WinUI/Data/ISoftDeletable.cs
+++ b/src/MZikmund.Toolkit.WinUI/Data/ISoftDeletable.cs
@@ -1,0 +1,39 @@
+namespace MZikmund.Toolkit.WinUI.Data;
+
+/// <summary>
+/// Marks an entity that supports soft-delete semantics — <see cref="IsDeleted"/>
+/// flips to <see langword="true"/> on a "delete" instead of removing the row,
+/// and <see cref="DeletedAt"/> records when.
+/// </summary>
+/// <remarks>
+/// Apps using EF Core typically apply a global query filter and intercept
+/// <c>Remove</c> in their DbContext:
+/// <code>
+/// // In OnModelCreating:
+/// foreach (var et in modelBuilder.Model.GetEntityTypes())
+/// {
+///     if (typeof(ISoftDeletable).IsAssignableFrom(et.ClrType))
+///     {
+///         var param = Expression.Parameter(et.ClrType, "e");
+///         var body = Expression.Equal(
+///             Expression.Property(param, nameof(ISoftDeletable.IsDeleted)),
+///             Expression.Constant(false));
+///         modelBuilder.Entity(et.ClrType).HasQueryFilter(Expression.Lambda(body, param));
+///     }
+/// }
+/// // In SaveChangesAsync override, swap Deleted state to Modified after marking:
+/// foreach (var entry in ChangeTracker.Entries&lt;ISoftDeletable&gt;().Where(e =&gt; e.State == EntityState.Deleted))
+/// {
+///     entry.Entity.MarkDeleted();
+///     entry.State = EntityState.Modified;
+/// }
+/// </code>
+/// </remarks>
+public interface ISoftDeletable
+{
+    /// <summary><see langword="true"/> when the entity is logically deleted.</summary>
+    bool IsDeleted { get; set; }
+
+    /// <summary>UTC timestamp recorded when the entity was soft-deleted; <see langword="null"/> while live.</summary>
+    DateTime? DeletedAt { get; set; }
+}

--- a/src/MZikmund.Toolkit.WinUI/Data/SoftDeletableExtensions.cs
+++ b/src/MZikmund.Toolkit.WinUI/Data/SoftDeletableExtensions.cs
@@ -1,0 +1,32 @@
+namespace MZikmund.Toolkit.WinUI.Data;
+
+/// <summary>
+/// Helpers for flipping <see cref="ISoftDeletable.IsDeleted"/> /
+/// <see cref="ISoftDeletable.DeletedAt"/>.
+/// </summary>
+public static class SoftDeletableExtensions
+{
+    /// <summary>
+    /// Sets <see cref="ISoftDeletable.IsDeleted"/> to <see langword="true"/> and stamps
+    /// <see cref="ISoftDeletable.DeletedAt"/>.
+    /// </summary>
+    /// <param name="entity">Entity to mark as deleted.</param>
+    /// <param name="at">Optional timestamp; defaults to <see cref="DateTime.UtcNow"/>.</param>
+    public static void MarkDeleted(this ISoftDeletable entity, DateTime? at = null)
+    {
+        ArgumentNullException.ThrowIfNull(entity);
+        entity.IsDeleted = true;
+        entity.DeletedAt = at ?? DateTime.UtcNow;
+    }
+
+    /// <summary>
+    /// Restores a previously soft-deleted entity by clearing <see cref="ISoftDeletable.IsDeleted"/>
+    /// and <see cref="ISoftDeletable.DeletedAt"/>.
+    /// </summary>
+    public static void Restore(this ISoftDeletable entity)
+    {
+        ArgumentNullException.ThrowIfNull(entity);
+        entity.IsDeleted = false;
+        entity.DeletedAt = null;
+    }
+}

--- a/tests/MZikmund.Toolkit.WinUI.Tests/AuditableSoftDeletableTests.cs
+++ b/tests/MZikmund.Toolkit.WinUI.Tests/AuditableSoftDeletableTests.cs
@@ -1,0 +1,126 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MZikmund.Toolkit.WinUI.Data;
+
+namespace MZikmund.Toolkit.WinUI.Tests;
+
+[TestClass]
+public class AuditableEntityExtensionsTests
+{
+    [TestMethod]
+    public void StampForCreate_NullEntity_Throws()
+    {
+        IAuditableEntity? entity = null;
+
+        Assert.Throws<ArgumentNullException>(() => entity!.StampForCreate());
+    }
+
+    [TestMethod]
+    public void StampForCreate_AssignsBothTimestamps()
+    {
+        var entity = new TestEntity();
+        var at = new DateTime(2024, 1, 2, 3, 4, 5, DateTimeKind.Utc);
+
+        entity.StampForCreate(at);
+
+        Assert.AreEqual(at, entity.CreatedAt);
+        Assert.AreEqual(at, entity.LastModifiedAt);
+    }
+
+    [TestMethod]
+    public void StampForCreate_NoTimestamp_DefaultsToUtcNow()
+    {
+        var entity = new TestEntity();
+        var before = DateTime.UtcNow;
+
+        entity.StampForCreate();
+
+        var after = DateTime.UtcNow;
+        Assert.IsTrue(entity.CreatedAt >= before && entity.CreatedAt <= after);
+        Assert.AreEqual(entity.CreatedAt, entity.LastModifiedAt);
+    }
+
+    [TestMethod]
+    public void StampForUpdate_OnlyUpdatesLastModifiedAt()
+    {
+        var entity = new TestEntity
+        {
+            CreatedAt = new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            LastModifiedAt = new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+        };
+        var at = new DateTime(2024, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        entity.StampForUpdate(at);
+
+        Assert.AreEqual(new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc), entity.CreatedAt);
+        Assert.AreEqual(at, entity.LastModifiedAt);
+    }
+
+    private sealed class TestEntity : IAuditableEntity
+    {
+        public DateTime CreatedAt { get; set; }
+        public DateTime LastModifiedAt { get; set; }
+    }
+}
+
+[TestClass]
+public class SoftDeletableExtensionsTests
+{
+    [TestMethod]
+    public void MarkDeleted_NullEntity_Throws()
+    {
+        ISoftDeletable? entity = null;
+
+        Assert.Throws<ArgumentNullException>(() => entity!.MarkDeleted());
+    }
+
+    [TestMethod]
+    public void Restore_NullEntity_Throws()
+    {
+        ISoftDeletable? entity = null;
+
+        Assert.Throws<ArgumentNullException>(() => entity!.Restore());
+    }
+
+    [TestMethod]
+    public void MarkDeleted_FlipsFlagAndStampsTimestamp()
+    {
+        var entity = new TestEntity();
+        var at = new DateTime(2024, 5, 6, 7, 8, 9, DateTimeKind.Utc);
+
+        entity.MarkDeleted(at);
+
+        Assert.IsTrue(entity.IsDeleted);
+        Assert.AreEqual(at, entity.DeletedAt);
+    }
+
+    [TestMethod]
+    public void MarkDeleted_NoTimestamp_DefaultsToUtcNow()
+    {
+        var entity = new TestEntity();
+        var before = DateTime.UtcNow;
+
+        entity.MarkDeleted();
+
+        var after = DateTime.UtcNow;
+        Assert.IsTrue(entity.IsDeleted);
+        Assert.IsNotNull(entity.DeletedAt);
+        Assert.IsTrue(entity.DeletedAt >= before && entity.DeletedAt <= after);
+    }
+
+    [TestMethod]
+    public void Restore_ClearsFlagAndTimestamp()
+    {
+        var entity = new TestEntity { IsDeleted = true, DeletedAt = DateTime.UtcNow };
+
+        entity.Restore();
+
+        Assert.IsFalse(entity.IsDeleted);
+        Assert.IsNull(entity.DeletedAt);
+    }
+
+    private sealed class TestEntity : ISoftDeletable
+    {
+        public bool IsDeleted { get; set; }
+        public DateTime? DeletedAt { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary

Adds the entity-marker interfaces from #42 under `MZikmund.Toolkit.WinUI.Data`:

- **`IAuditableEntity`** — `DateTime CreatedAt`, `DateTime LastModifiedAt`.
- **`ISoftDeletable`** — `bool IsDeleted`, `DateTime? DeletedAt`.
- **`AuditableEntityExtensions`** — `StampForCreate(at?)` (sets both timestamps) and `StampForUpdate(at?)` (only `LastModifiedAt`). Defaults to `DateTime.UtcNow` when no timestamp is given.
- **`SoftDeletableExtensions`** — `MarkDeleted(at?)` and `Restore()`.

### Decision: no EF Core dependency in the toolkit

The issue called for a `DbContext` extension or base class. After review, this PR ships only the markers and stamping helpers — the toolkit (a UI-focused package) deliberately doesn't take an EF Core dependency. Apps wire the markers into EF Core themselves; the XML-doc comments on each interface include the canonical snippets:

- `SaveChangesAsync` override that walks `ChangeTracker.Entries<IAuditableEntity>()` and calls `StampForCreate` / `StampForUpdate`.
- `OnModelCreating` loop that adds a global query filter on `ISoftDeletable.IsDeleted == false`.
- `SaveChangesAsync` override that flips `EntityState.Deleted` to `Modified` after `MarkDeleted` on `ISoftDeletable` entries.

If a future `MZikmund.Toolkit.EntityFrameworkCore` package is desired (per the issue's "_New package_" suggestion), it can ship the DbContext base on top of these markers without breaking changes.

Wires a gallery sample (`AuditableEntitySamplePage`) into Shell + HomePage with a `Reminder` mock that implements both interfaces. Buttons exercise `Create` (`StampForCreate`), `Update` (`StampForUpdate`), `Delete` (`MarkDeleted`), and `Restore` — the live timestamps + flags update visibly.

Adds 9 unit tests covering null-arg guards, the create/update timestamp invariants (`CreatedAt` not modified by `StampForUpdate`), the `UtcNow` default, and the `MarkDeleted` / `Restore` round-trip.

Closes #42

> Stacked on top of #56 (the `MergeWith` PR). Rebase on `main` once #56 merges.

## Test plan

- [x] `dotnet build MZikmund.Toolkit.slnx -c Debug` succeeds.
- [x] Test exe reports 23/23 passed (14 prior + 9 new).
- [ ] Manually exercise the `Auditable / Soft-Delete` sample on Windows: click Create — `CreatedAt` and `LastModifiedAt` are equal; wait a beat and click Update — only `LastModifiedAt` advances; click Delete — `IsDeleted = True` and `DeletedAt` is stamped; click Restore — both clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)