### PR TITLE
feat: Add Disposable.Create ad-hoc IDisposable factory

### DIFF
--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/DisposableSamplePage.xaml
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/DisposableSamplePage.xaml
@@ -1,0 +1,57 @@
+<Page x:Class="MZikmund.Toolkit.Sample.DisposableSamplePage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:local="using:MZikmund.Toolkit.Sample">
+
+  <ScrollViewer Padding="24">
+    <StackPanel Spacing="16" MaxWidth="800">
+      <TextBlock Text="Disposable.Create"
+                 Style="{ThemeResource TitleTextBlockStyle}" />
+
+      <TextBlock Text="Disposable.Create(Action) returns an IDisposable that runs the action exactly once on first Dispose. Useful as the building block for any 'do X for the duration of this scope' pattern — including the loading-flag scope this issue was named after — without writing a one-off nested class each time."
+                 TextWrapping="Wrap"
+                 Style="{ThemeResource BodyTextBlockStyle}" />
+
+      <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+              BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+              BorderThickness="1"
+              CornerRadius="8"
+              Padding="16">
+        <StackPanel Spacing="12">
+          <TextBlock Text="Live demo: loading-scope pattern"
+                     Style="{ThemeResource SubtitleTextBlockStyle}" />
+
+          <TextBlock Text="The button toggles IsLoading=true at scope start and resets it on Dispose. The progress ring tracks IsLoading."
+                     TextWrapping="Wrap"
+                     Style="{ThemeResource BodyTextBlockStyle}" />
+
+          <Button Content="Run 2-second job" Click="RunJob_Click" Style="{ThemeResource AccentButtonStyle}" />
+
+          <ProgressRing x:Name="LoadingRing" IsActive="False" HorizontalAlignment="Left" />
+
+          <TextBlock x:Name="StateText" Style="{ThemeResource BodyStrongTextBlockStyle}" Text="Idle." />
+        </StackPanel>
+      </Border>
+
+      <Border Background="{ThemeResource LayerFillColorDefaultBrush}"
+              BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+              BorderThickness="1"
+              CornerRadius="8"
+              Padding="16">
+        <StackPanel Spacing="8">
+          <TextBlock Text="Code Sample"
+                     Style="{ThemeResource SubtitleTextBlockStyle}" />
+
+          <TextBlock FontFamily="Consolas" TextWrapping="Wrap">
+            <Run>using MZikmund.Toolkit.WinUI.Disposables;</Run><LineBreak />
+            <LineBreak />
+            <Run>IsLoading = true;</Run><LineBreak />
+            <Run>using var _ = Disposable.Create(() =&gt; IsLoading = false);</Run><LineBreak />
+            <Run>await DoWorkAsync();</Run><LineBreak />
+            <Run>// IsLoading flips back to false when the scope ends, even on exception.</Run>
+          </TextBlock>
+        </StackPanel>
+      </Border>
+    </StackPanel>
+  </ScrollViewer>
+</Page>

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/DisposableSamplePage.xaml.cs
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/DisposableSamplePage.xaml.cs
@@ -1,0 +1,26 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using MZikmund.Toolkit.WinUI.Disposables;
+
+namespace MZikmund.Toolkit.Sample;
+
+public sealed partial class DisposableSamplePage : Page
+{
+    public DisposableSamplePage()
+    {
+        this.InitializeComponent();
+    }
+
+    private async void RunJob_Click(object sender, RoutedEventArgs e)
+    {
+        LoadingRing.IsActive = true;
+        StateText.Text = "Working…";
+        using var scope = Disposable.Create(() =>
+        {
+            LoadingRing.IsActive = false;
+            StateText.Text = "Idle.";
+        });
+
+        await Task.Delay(TimeSpan.FromSeconds(2));
+    }
+}

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/HomePage.xaml
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/HomePage.xaml
@@ -40,6 +40,12 @@
           <Run Text="ObservableCollection Merge:" FontWeight="SemiBold" />
           <Run Text=" MergeWith extension that synchronizes an ObservableCollection with a source list using minimal Insert/RemoveAt/Move operations." />
         </TextBlock>
+
+        <TextBlock Style="{ThemeResource BodyTextBlockStyle}">
+          <Run Text="• " FontWeight="Bold" />
+          <Run Text="Disposable:" FontWeight="SemiBold" />
+          <Run Text=" Disposable.Create(Action) ad-hoc IDisposable factory for one-off using-scopes (loading flags, subscriptions, …)." />
+        </TextBlock>
         
         <TextBlock Style="{ThemeResource BodyTextBlockStyle}">
           <Run Text="• " FontWeight="Bold" />

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml
@@ -18,6 +18,7 @@
       <NavigationViewItemHeader Content="Extensions" />
       <NavigationViewItem Content="Package Version" Tag="PackageVersion" Icon="Document" />
       <NavigationViewItem Content="ObservableCollection Merge" Tag="ObservableCollectionMerge" Icon="List" />
+      <NavigationViewItem Content="Disposable" Tag="Disposable" Icon="Sync" />
       <NavigationViewItemHeader Content="Infrastructure" />
       <NavigationViewItem Content="XamlRoot Provider" Tag="XamlRootProvider" Icon="Page" />
     </NavigationView.MenuItems>

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml.cs
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml.cs
@@ -30,6 +30,7 @@ public sealed partial class Shell : Page
                 "DialogCoordinator" => typeof(DialogCoordinatorSamplePage),
                 "PackageVersion" => typeof(PackageVersionSamplePage),
                 "ObservableCollectionMerge" => typeof(ObservableCollectionMergeSamplePage),
+                "Disposable" => typeof(DisposableSamplePage),
                 "XamlRootProvider" => typeof(XamlRootProviderSamplePage),
                 _ => null
             };

--- a/src/MZikmund.Toolkit.WinUI/Disposables/Disposable.cs
+++ b/src/MZikmund.Toolkit.WinUI/Disposables/Disposable.cs
@@ -1,0 +1,49 @@
+namespace MZikmund.Toolkit.WinUI.Disposables;
+
+/// <summary>
+/// Factories for ad-hoc <see cref="IDisposable"/> values. Avoids the boilerplate of a
+/// nested class for one-off "do <em>X</em> on dispose" scopes.
+/// </summary>
+/// <example>
+/// "Loading scope" pattern — toggle a flag for the duration of an operation:
+/// <code>
+/// IsLoading = true;
+/// using var _ = Disposable.Create(() => IsLoading = false);
+/// await DoWorkAsync();
+/// </code>
+/// </example>
+public static class Disposable
+{
+    /// <summary>
+    /// Returns an <see cref="IDisposable"/> that runs <paramref name="onDispose"/> exactly
+    /// once, on first <see cref="IDisposable.Dispose"/>. Subsequent disposes are no-ops.
+    /// </summary>
+    /// <exception cref="ArgumentNullException"><paramref name="onDispose"/> is <see langword="null"/>.</exception>
+    public static IDisposable Create(Action onDispose)
+    {
+        ArgumentNullException.ThrowIfNull(onDispose);
+        return new ActionDisposable(onDispose);
+    }
+
+    /// <summary>
+    /// A no-op disposable. Useful as a default value or to short-circuit "no scope needed" branches.
+    /// </summary>
+    public static IDisposable Empty { get; } = new EmptyDisposable();
+
+    private sealed class ActionDisposable : IDisposable
+    {
+        private Action? _onDispose;
+
+        public ActionDisposable(Action onDispose) => _onDispose = onDispose;
+
+        public void Dispose() =>
+            Interlocked.Exchange(ref _onDispose, null)?.Invoke();
+    }
+
+    private sealed class EmptyDisposable : IDisposable
+    {
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/tests/MZikmund.Toolkit.WinUI.Tests/DisposableTests.cs
+++ b/tests/MZikmund.Toolkit.WinUI.Tests/DisposableTests.cs
@@ -1,0 +1,74 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MZikmund.Toolkit.WinUI.Disposables;
+
+namespace MZikmund.Toolkit.WinUI.Tests;
+
+[TestClass]
+public class DisposableTests
+{
+    [TestMethod]
+    public void Create_NullAction_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => Disposable.Create(null!));
+    }
+
+    [TestMethod]
+    public void Dispose_RunsActionOnce()
+    {
+        var count = 0;
+        var sut = Disposable.Create(() => count++);
+
+        sut.Dispose();
+
+        Assert.AreEqual(1, count);
+    }
+
+    [TestMethod]
+    public void Dispose_MultipleTimes_RunsActionExactlyOnce()
+    {
+        var count = 0;
+        var sut = Disposable.Create(() => count++);
+
+        sut.Dispose();
+        sut.Dispose();
+        sut.Dispose();
+
+        Assert.AreEqual(1, count);
+    }
+
+    [TestMethod]
+    public void Dispose_PropagatesExceptionFromAction()
+    {
+        var sut = Disposable.Create(() => throw new InvalidOperationException("boom"));
+
+        Assert.Throws<InvalidOperationException>(() => sut.Dispose());
+    }
+
+    [TestMethod]
+    public void Empty_DoesNothing()
+    {
+        var sut = Disposable.Empty;
+
+        sut.Dispose();
+        sut.Dispose();
+        // No exception ⇒ pass.
+    }
+
+    [TestMethod]
+    public void Empty_ReturnsSameInstance()
+    {
+        Assert.AreSame(Disposable.Empty, Disposable.Empty);
+    }
+
+    [TestMethod]
+    public void UsingScope_RunsActionOnExit()
+    {
+        var count = 0;
+        using (Disposable.Create(() => count++))
+        {
+            Assert.AreEqual(0, count);
+        }
+
+        Assert.AreEqual(1, count);
+    }
+}


### PR DESCRIPTION
## Summary

Adds `Disposable.Create(Action)` and `Disposable.Empty` in `MZikmund.Toolkit.WinUI.Disposables`:

- **`Disposable.Create(Action onDispose)`** returns an `IDisposable` that runs `onDispose` exactly once on first `Dispose`. Subsequent disposes are no-ops. Throws `ArgumentNullException` if `onDispose` is null.
- **`Disposable.Empty`** is the shared no-op `IDisposable` singleton (useful as a default value).

Useful as the building block for any "do X for the duration of this scope" pattern — the loading-flag scope this issue is named after, but also event-handler subscriptions, transient theme overrides, etc. — without writing a one-off nested class each time:

```csharp
IsLoading = true;
using var _ = Disposable.Create(() => IsLoading = false);
await DoWorkAsync();
```

The complementary higher-level abstraction with reference counting + `IWindowShellViewModel` integration ships separately as `ILoadingIndicator` (#43 / PR #74). This PR is the simpler primitive that doesn't require a shell.

Wires a gallery sample (`DisposableSamplePage`) into Shell + HomePage with a button that runs a 2-second job inside a loading-scope disposable.

Adds 7 unit tests covering null-arg, single-run-on-dispose, idempotent multi-dispose, exception propagation from the action, the empty-singleton no-op behavior, and the canonical `using`-scope flow.

> The issue body was empty so the title was the only specification — this PR ships the most direct interpretation: a disposable that fires an action when disposed, suitable for the "loading scope" pattern named in the title and many other usages.

Closes #14

> Stacked on top of #56 (the `MergeWith` PR). Rebase on `main` once #56 merges.

## Test plan

- [x] `dotnet build MZikmund.Toolkit.slnx -c Debug` succeeds.
- [x] Test exe reports 21/21 passed (14 prior + 7 new).
- [ ] Manually exercise the `Disposable` sample on Windows: click `Run 2-second job`, confirm the progress ring spins for ~2 s and the status flips back to `Idle.` automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)