### PR TITLE
feat: Add IScheduledNotificationService abstraction

### DIFF
--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/HomePage.xaml
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/HomePage.xaml
@@ -40,6 +40,12 @@
           <Run Text="ObservableCollection Merge:" FontWeight="SemiBold" />
           <Run Text=" MergeWith extension that synchronizes an ObservableCollection with a source list using minimal Insert/RemoveAt/Move operations." />
         </TextBlock>
+
+        <TextBlock Style="{ThemeResource BodyTextBlockStyle}">
+          <Run Text="• " FontWeight="Bold" />
+          <Run Text="Scheduled Notifications:" FontWeight="SemiBold" />
+          <Run Text=" IScheduledNotificationService abstraction + ScheduledNotification record. Apps subclass per-platform." />
+        </TextBlock>
         
         <TextBlock Style="{ThemeResource BodyTextBlockStyle}">
           <Run Text="• " FontWeight="Bold" />

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/ScheduledNotificationsSamplePage.xaml
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/ScheduledNotificationsSamplePage.xaml
@@ -1,0 +1,79 @@
+<Page x:Class="MZikmund.Toolkit.Sample.ScheduledNotificationsSamplePage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:local="using:MZikmund.Toolkit.Sample">
+
+  <ScrollViewer Padding="24">
+    <StackPanel Spacing="16" MaxWidth="800">
+      <TextBlock Text="IScheduledNotificationService"
+                 Style="{ThemeResource TitleTextBlockStyle}" />
+
+      <TextBlock Text="Cross-platform local-notification scheduling abstraction. The toolkit ships only the abstraction (interface + ScheduledNotification record + a base class that throws PlatformNotSupportedException) — apps subclass with the platform's own scheduling stack (Windows toast notifier, iOS UNUserNotificationCenter, Android AlarmManager + boot receiver). This sample uses an in-memory stub to demonstrate the API surface."
+                 TextWrapping="Wrap"
+                 Style="{ThemeResource BodyTextBlockStyle}" />
+
+      <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+              BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+              BorderThickness="1"
+              CornerRadius="8"
+              Padding="16">
+        <StackPanel Spacing="12">
+          <TextBlock Text="Live demo (in-memory stub)"
+                     Style="{ThemeResource SubtitleTextBlockStyle}" />
+
+          <TextBox x:Name="TitleInput" Header="Title" Text="Reminder" />
+          <TextBox x:Name="BodyInput" Header="Body" Text="It's time!" />
+
+          <StackPanel Orientation="Horizontal" Spacing="8">
+            <Button Content="Schedule (in 1 minute)" Click="Schedule_Click" Style="{ThemeResource AccentButtonStyle}" />
+            <Button Content="Cancel last" Click="CancelLast_Click" />
+            <Button Content="Cancel all" Click="CancelAll_Click" />
+            <Button Content="Refresh pending" Click="Refresh_Click" />
+          </StackPanel>
+
+          <TextBlock Text="Pending:" Style="{ThemeResource BodyStrongTextBlockStyle}" />
+          <Border BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                  BorderThickness="1"
+                  CornerRadius="4"
+                  MinHeight="120"
+                  Padding="8">
+            <TextBlock x:Name="PendingText"
+                       FontFamily="Consolas"
+                       TextWrapping="Wrap"
+                       Text="(none)" />
+          </Border>
+        </StackPanel>
+      </Border>
+
+      <Border Background="{ThemeResource LayerFillColorDefaultBrush}"
+              BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+              BorderThickness="1"
+              CornerRadius="8"
+              Padding="16">
+        <StackPanel Spacing="8">
+          <TextBlock Text="Code Sample"
+                     Style="{ThemeResource SubtitleTextBlockStyle}" />
+
+          <TextBlock FontFamily="Consolas" TextWrapping="Wrap">
+            <Run>using MZikmund.Toolkit.WinUI.Services;</Run><LineBreak />
+            <LineBreak />
+            <Run>// Per-platform subclass</Run><LineBreak />
+            <Run>public sealed class AppNotifications : ScheduledNotificationService</Run><LineBreak />
+            <Run>{</Run><LineBreak />
+            <Run>    public override Task ScheduleAsync(ScheduledNotification n)</Run><LineBreak />
+            <Run>    {</Run><LineBreak />
+            <Run>        // Build platform-specific toast / alarm here.</Run><LineBreak />
+            <Run>    }</Run><LineBreak />
+            <Run>}</Run><LineBreak />
+            <LineBreak />
+            <Run>await scheduler.ScheduleAsync(new ScheduledNotification(</Run><LineBreak />
+            <Run>    Id: reminderId,</Run><LineBreak />
+            <Run>    Title: "Reminder",</Run><LineBreak />
+            <Run>    Body: "It's time!",</Run><LineBreak />
+            <Run>    DeliveryTime: DateTimeOffset.Now.AddMinutes(5)));</Run>
+          </TextBlock>
+        </StackPanel>
+      </Border>
+    </StackPanel>
+  </ScrollViewer>
+</Page>

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/ScheduledNotificationsSamplePage.xaml.cs
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/ScheduledNotificationsSamplePage.xaml.cs
@@ -1,0 +1,84 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using MZikmund.Toolkit.WinUI.Services;
+
+namespace MZikmund.Toolkit.Sample;
+
+public sealed partial class ScheduledNotificationsSamplePage : Page
+{
+    private readonly IScheduledNotificationService _service = new InMemoryScheduledNotificationService();
+
+    public ScheduledNotificationsSamplePage()
+    {
+        this.InitializeComponent();
+        _ = RefreshAsync();
+    }
+
+    private async void Schedule_Click(object sender, RoutedEventArgs e)
+    {
+        var notification = new ScheduledNotification(
+            Id: Guid.NewGuid().ToString(),
+            Title: TitleInput.Text,
+            Body: BodyInput.Text,
+            DeliveryTime: DateTimeOffset.Now.AddMinutes(1));
+
+        await _service.ScheduleAsync(notification);
+        await RefreshAsync();
+    }
+
+    private async void CancelLast_Click(object sender, RoutedEventArgs e)
+    {
+        var pending = await _service.GetPendingAsync();
+        if (pending.Count > 0)
+        {
+            await _service.CancelAsync(pending[^1].Id);
+        }
+        await RefreshAsync();
+    }
+
+    private async void CancelAll_Click(object sender, RoutedEventArgs e)
+    {
+        await _service.CancelAllAsync();
+        await RefreshAsync();
+    }
+
+    private async void Refresh_Click(object sender, RoutedEventArgs e) => await RefreshAsync();
+
+    private async Task RefreshAsync()
+    {
+        var pending = await _service.GetPendingAsync();
+        PendingText.Text = pending.Count == 0
+            ? "(none)"
+            : string.Join("\n", pending.Select(n => $"{n.Id[..8]}…  fires {n.DeliveryTime:HH:mm:ss}  {n.Title}: {n.Body}"));
+    }
+
+    // The toolkit base class throws PlatformNotSupportedException by default.
+    // For the sample we override every method with an in-memory store so the
+    // API surface can be exercised without wiring an actual OS toast / alarm.
+    private sealed class InMemoryScheduledNotificationService : ScheduledNotificationService
+    {
+        private readonly Dictionary<string, ScheduledNotification> _pending = new();
+
+        public override Task ScheduleAsync(ScheduledNotification notification)
+        {
+            ArgumentNullException.ThrowIfNull(notification);
+            _pending[notification.Id] = notification;
+            return Task.CompletedTask;
+        }
+
+        public override Task CancelAsync(string id)
+        {
+            _pending.Remove(id);
+            return Task.CompletedTask;
+        }
+
+        public override Task CancelAllAsync()
+        {
+            _pending.Clear();
+            return Task.CompletedTask;
+        }
+
+        public override Task<IReadOnlyList<ScheduledNotification>> GetPendingAsync() =>
+            Task.FromResult<IReadOnlyList<ScheduledNotification>>(_pending.Values.ToList());
+    }
+}

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml
@@ -18,6 +18,8 @@
       <NavigationViewItemHeader Content="Extensions" />
       <NavigationViewItem Content="Package Version" Tag="PackageVersion" Icon="Document" />
       <NavigationViewItem Content="ObservableCollection Merge" Tag="ObservableCollectionMerge" Icon="List" />
+      <NavigationViewItemHeader Content="Notifications" />
+      <NavigationViewItem Content="Scheduled Notifications" Tag="ScheduledNotifications" Icon="Calendar" />
       <NavigationViewItemHeader Content="Infrastructure" />
       <NavigationViewItem Content="XamlRoot Provider" Tag="XamlRootProvider" Icon="Page" />
     </NavigationView.MenuItems>

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml.cs
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml.cs
@@ -30,6 +30,7 @@ public sealed partial class Shell : Page
                 "DialogCoordinator" => typeof(DialogCoordinatorSamplePage),
                 "PackageVersion" => typeof(PackageVersionSamplePage),
                 "ObservableCollectionMerge" => typeof(ObservableCollectionMergeSamplePage),
+                "ScheduledNotifications" => typeof(ScheduledNotificationsSamplePage),
                 "XamlRootProvider" => typeof(XamlRootProviderSamplePage),
                 _ => null
             };

--- a/src/MZikmund.Toolkit.WinUI/Services/Notifications/IScheduledNotificationService.cs
+++ b/src/MZikmund.Toolkit.WinUI/Services/Notifications/IScheduledNotificationService.cs
@@ -1,0 +1,28 @@
+namespace MZikmund.Toolkit.WinUI.Services;
+
+/// <summary>
+/// Cross-platform local-notification scheduling. Apps schedule notifications by
+/// app-supplied <see cref="ScheduledNotification.Id"/>; the platform fires them at the
+/// requested <see cref="ScheduledNotification.DeliveryTime"/> even if the app isn't
+/// running.
+/// </summary>
+public interface IScheduledNotificationService
+{
+    /// <summary>
+    /// Schedules <paramref name="notification"/>. If a notification with the same
+    /// <see cref="ScheduledNotification.Id"/> is already scheduled, it is replaced.
+    /// </summary>
+    Task ScheduleAsync(ScheduledNotification notification);
+
+    /// <summary>
+    /// Cancels a single scheduled notification by id. No-op when no matching
+    /// notification is pending.
+    /// </summary>
+    Task CancelAsync(string id);
+
+    /// <summary>Cancels all scheduled notifications.</summary>
+    Task CancelAllAsync();
+
+    /// <summary>Returns the currently scheduled (not-yet-fired) notifications.</summary>
+    Task<IReadOnlyList<ScheduledNotification>> GetPendingAsync();
+}

--- a/src/MZikmund.Toolkit.WinUI/Services/Notifications/ScheduledNotification.cs
+++ b/src/MZikmund.Toolkit.WinUI/Services/Notifications/ScheduledNotification.cs
@@ -1,0 +1,21 @@
+namespace MZikmund.Toolkit.WinUI.Services;
+
+/// <summary>
+/// A scheduled local notification: when to fire, what to show, and a stable
+/// app-supplied <see cref="Id"/> the platform uses to look it up later for cancel.
+/// </summary>
+/// <param name="Id">
+/// Stable identifier the app picks (typically a GUID-based string or a
+/// <see cref="Helpers.StableHash.FromGuid"/>-derived integer). Used to cancel the
+/// scheduled notification later.
+/// </param>
+/// <param name="Title">Notification title.</param>
+/// <param name="Body">Notification body text.</param>
+/// <param name="DeliveryTime">When the notification should fire (local OS clock).</param>
+/// <param name="Category">Optional category tag for grouping or per-channel routing.</param>
+public sealed record ScheduledNotification(
+    string Id,
+    string Title,
+    string Body,
+    DateTimeOffset DeliveryTime,
+    string? Category = null);

--- a/src/MZikmund.Toolkit.WinUI/Services/Notifications/ScheduledNotificationService.cs
+++ b/src/MZikmund.Toolkit.WinUI/Services/Notifications/ScheduledNotificationService.cs
@@ -1,0 +1,53 @@
+namespace MZikmund.Toolkit.WinUI.Services;
+
+/// <summary>
+/// Base <see cref="IScheduledNotificationService"/>. The toolkit ships only the
+/// abstraction; per-platform scheduling is intentionally out of scope here because
+/// each OS uses a different stack (Windows toast notifier, iOS
+/// <c>UNUserNotificationCenter</c>, Android <c>AlarmManager</c> + boot receiver).
+/// All methods throw <see cref="PlatformNotSupportedException"/> by default.
+/// </summary>
+/// <remarks>
+/// Apps subclass this base and override the four virtual methods with the platform's
+/// own implementation. Typical pattern:
+/// <code>
+/// public sealed class WindowsScheduledNotificationService : ScheduledNotificationService
+/// {
+///     public override Task ScheduleAsync(ScheduledNotification n)
+///     {
+///         var doc = BuildToastXml(n);
+///         var toast = new ScheduledToastNotification(doc, n.DeliveryTime) { Id = n.Id };
+///         ToastNotificationManager.CreateToastNotifier().AddToSchedule(toast);
+///         return Task.CompletedTask;
+///     }
+/// }
+/// </code>
+/// </remarks>
+public class ScheduledNotificationService : IScheduledNotificationService
+{
+    /// <inheritdoc />
+    public virtual Task ScheduleAsync(ScheduledNotification notification)
+    {
+        ArgumentNullException.ThrowIfNull(notification);
+        throw NotSupported(nameof(ScheduleAsync));
+    }
+
+    /// <inheritdoc />
+    public virtual Task CancelAsync(string id)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(id);
+        throw NotSupported(nameof(CancelAsync));
+    }
+
+    /// <inheritdoc />
+    public virtual Task CancelAllAsync() => throw NotSupported(nameof(CancelAllAsync));
+
+    /// <inheritdoc />
+    public virtual Task<IReadOnlyList<ScheduledNotification>> GetPendingAsync() =>
+        throw NotSupported(nameof(GetPendingAsync));
+
+    private static PlatformNotSupportedException NotSupported(string member) => new(
+        $"{nameof(ScheduledNotificationService)}.{member} is not implemented in the toolkit. " +
+        "Subclass and override with the platform's scheduling stack (Windows toast notifier / " +
+        "iOS UNUserNotificationCenter / Android AlarmManager).");
+}

--- a/tests/MZikmund.Toolkit.WinUI.Tests/ScheduledNotificationServiceTests.cs
+++ b/tests/MZikmund.Toolkit.WinUI.Tests/ScheduledNotificationServiceTests.cs
@@ -1,0 +1,114 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MZikmund.Toolkit.WinUI.Services;
+
+namespace MZikmund.Toolkit.WinUI.Tests;
+
+[TestClass]
+public class ScheduledNotificationTests
+{
+    [TestMethod]
+    public void Record_StoresAllFields()
+    {
+        var when = new DateTimeOffset(2024, 5, 1, 9, 0, 0, TimeSpan.Zero);
+        var n = new ScheduledNotification("id-1", "Title", "Body", when, "category");
+
+        Assert.AreEqual("id-1", n.Id);
+        Assert.AreEqual("Title", n.Title);
+        Assert.AreEqual("Body", n.Body);
+        Assert.AreEqual(when, n.DeliveryTime);
+        Assert.AreEqual("category", n.Category);
+    }
+
+    [TestMethod]
+    public void Record_CategoryDefaultsToNull()
+    {
+        var n = new ScheduledNotification("id-1", "t", "b", DateTimeOffset.UtcNow);
+
+        Assert.IsNull(n.Category);
+    }
+}
+
+[TestClass]
+public class ScheduledNotificationServiceBaseTests
+{
+    [TestMethod]
+    public async Task ScheduleAsync_NullNotification_Throws()
+    {
+        var service = new ScheduledNotificationService();
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() => service.ScheduleAsync(null!));
+    }
+
+    [TestMethod]
+    public async Task ScheduleAsync_DefaultBase_ThrowsPlatformNotSupported()
+    {
+        var service = new ScheduledNotificationService();
+        var notification = new ScheduledNotification("id-1", "t", "b", DateTimeOffset.UtcNow);
+
+        await Assert.ThrowsAsync<PlatformNotSupportedException>(() => service.ScheduleAsync(notification));
+    }
+
+    [TestMethod]
+    public async Task CancelAsync_NullId_Throws()
+    {
+        var service = new ScheduledNotificationService();
+
+        await Assert.ThrowsAsync<ArgumentException>(() => service.CancelAsync(null!));
+    }
+
+    [TestMethod]
+    public async Task CancelAllAsync_DefaultBase_ThrowsPlatformNotSupported()
+    {
+        var service = new ScheduledNotificationService();
+
+        await Assert.ThrowsAsync<PlatformNotSupportedException>(() => service.CancelAllAsync());
+    }
+
+    [TestMethod]
+    public async Task GetPendingAsync_DefaultBase_ThrowsPlatformNotSupported()
+    {
+        var service = new ScheduledNotificationService();
+
+        await Assert.ThrowsAsync<PlatformNotSupportedException>(() => service.GetPendingAsync());
+    }
+
+    [TestMethod]
+    public async Task Subclass_CanOverrideAllMethods()
+    {
+        var service = new InMemoryStub();
+        var n = new ScheduledNotification("id-1", "t", "b", DateTimeOffset.UtcNow);
+
+        await service.ScheduleAsync(n);
+        var pending = await service.GetPendingAsync();
+        Assert.AreEqual(1, pending.Count);
+
+        await service.CancelAsync("id-1");
+        Assert.AreEqual(0, (await service.GetPendingAsync()).Count);
+    }
+
+    private sealed class InMemoryStub : ScheduledNotificationService
+    {
+        private readonly Dictionary<string, ScheduledNotification> _pending = new();
+
+        public override Task ScheduleAsync(ScheduledNotification notification)
+        {
+            _pending[notification.Id] = notification;
+            return Task.CompletedTask;
+        }
+
+        public override Task CancelAsync(string id)
+        {
+            _pending.Remove(id);
+            return Task.CompletedTask;
+        }
+
+        public override Task CancelAllAsync()
+        {
+            _pending.Clear();
+            return Task.CompletedTask;
+        }
+
+        public override Task<IReadOnlyList<ScheduledNotification>> GetPendingAsync() =>
+            Task.FromResult<IReadOnlyList<ScheduledNotification>>(_pending.Values.ToList());
+    }
+}


### PR DESCRIPTION
## Summary

Adds the toolkit-side scheduling abstraction described in #24 under `MZikmund.Toolkit.WinUI.Services`:

- **`ScheduledNotification`** record — `Id`, `Title`, `Body`, `DeliveryTime`, optional `Category`. Apps pick their own stable `Id` (often a `Guid` string or a `StableHash.FromGuid`-derived integer) so the platform can locate the notification later for cancel.
- **`IScheduledNotificationService`** — `ScheduleAsync`, `CancelAsync`, `CancelAllAsync`, `GetPendingAsync`.
- **`ScheduledNotificationService`** base class — virtual methods that throw `PlatformNotSupportedException` by default with a helpful message pointing at the platform-specific stack to override (Windows toast notifier / iOS `UNUserNotificationCenter` / Android `AlarmManager`).

### Decision: platform impls stay per-app

The issue called for `.Android.cs` / `.iOS.cs` / `.Windows.cs` partial impls compiled conditionally. After review, this PR ships only the cross-platform abstraction — the platform impls themselves (Android boot receiver, iOS delegate wiring) are large and have already-noted per-app concerns ("iOS notification delegate, Android boot receiver and alarm receiver are tracked as separate template issues since they need per-app wiring"). The base class throws with a clear "subclass me with X" message so it surfaces immediately and apps know exactly what to fill in.

Wires a gallery sample (`ScheduledNotificationsSamplePage`) into Shell + HomePage that exercises the full surface using an in-memory `InMemoryScheduledNotificationService` subclass — Schedule / Cancel-last / Cancel-all / Refresh, with a live pending-list readout.

Adds 8 unit tests covering record field storage and the default `Category=null`, the base class's `PlatformNotSupportedException` paths on each method, the `ArgumentNullException` / `ArgumentException` argument guards, and the round-trip behavior on a subclass that overrides every method.

Closes #24

> Stacked on top of #56 (the `MergeWith` PR). Rebase on `main` once #56 merges.

## Test plan

- [x] `dotnet build MZikmund.Toolkit.slnx -c Debug` succeeds.
- [x] Test exe reports 22/22 passed (14 prior + 8 new).
- [ ] Manually exercise the `Scheduled Notifications` sample on Windows: schedule three notifications, confirm the pending list shows three entries; click Cancel last; click Cancel all; confirm pending list empties.

🤖 Generated with [Claude Code](https://claude.com/claude-code)