### PR TITLE
feat: Add SqliteDataServiceBase + migrations + batch chunking

### DIFF
--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/HomePage.xaml
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/HomePage.xaml
@@ -40,6 +40,12 @@
           <Run Text="ObservableCollection Merge:" FontWeight="SemiBold" />
           <Run Text=" MergeWith extension that synchronizes an ObservableCollection with a source list using minimal Insert/RemoveAt/Move operations." />
         </TextBlock>
+
+        <TextBlock Style="{ThemeResource BodyTextBlockStyle}">
+          <Run Text="• " FontWeight="Bold" />
+          <Run Text="SQLite Data Service:" FontWeight="SemiBold" />
+          <Run Text=" SqliteDataServiceBase + UserVersionMigrationRunner + SqliteBatch.Chunk + DateRange for sqlite-net-pcl-backed apps." />
+        </TextBlock>
         
         <TextBlock Style="{ThemeResource BodyTextBlockStyle}">
           <Run Text="• " FontWeight="Bold" />

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/SqliteSamplePage.xaml
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/SqliteSamplePage.xaml
@@ -1,0 +1,77 @@
+<Page x:Class="MZikmund.Toolkit.Sample.SqliteSamplePage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:local="using:MZikmund.Toolkit.Sample">
+
+  <ScrollViewer Padding="24">
+    <StackPanel Spacing="16" MaxWidth="800">
+      <TextBlock Text="SqliteDataServiceBase + UserVersionMigrationRunner"
+                 Style="{ThemeResource TitleTextBlockStyle}" />
+
+      <TextBlock Text="The toolkit ships a SqliteDataServiceBase that lazy-initializes a SQLiteAsyncConnection and runs an IMigrationRunner. UserVersionMigrationRunner tracks schema version through PRAGMA user_version. SqliteBatch.Chunk slices large IN-batches under SQLite's 32766-parameter cap, and DateRange normalizes inclusive ticks-based ranges for indexed BETWEEN queries."
+                 TextWrapping="Wrap"
+                 Style="{ThemeResource BodyTextBlockStyle}" />
+
+      <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+              BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+              BorderThickness="1"
+              CornerRadius="8"
+              Padding="16">
+        <StackPanel Spacing="12">
+          <TextBlock Text="Live demo (in-memory SQLite)"
+                     Style="{ThemeResource SubtitleTextBlockStyle}" />
+
+          <TextBlock Text="Subclasses SqliteDataServiceBase against ':memory:'. Two migrations create a Reminder table and add a DueAtTicks column. Insert reminders, then query by date range."
+                     TextWrapping="Wrap"
+                     Style="{ThemeResource BodyTextBlockStyle}" />
+
+          <TextBox x:Name="TitleInput" Header="Title" Text="Walk the dog" />
+
+          <StackPanel Orientation="Horizontal" Spacing="8">
+            <Button Content="Initialize" Click="Init_Click" Style="{ThemeResource AccentButtonStyle}" />
+            <Button Content="Insert" Click="Insert_Click" />
+            <Button Content="Query (today)" Click="QueryToday_Click" />
+          </StackPanel>
+
+          <TextBlock x:Name="SchemaVersionText" Style="{ThemeResource BodyStrongTextBlockStyle}" />
+
+          <Border BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                  BorderThickness="1"
+                  CornerRadius="4"
+                  MinHeight="120"
+                  Padding="8">
+            <TextBlock x:Name="ResultsText"
+                       FontFamily="Consolas"
+                       TextWrapping="Wrap"
+                       Text="(no rows yet)" />
+          </Border>
+        </StackPanel>
+      </Border>
+
+      <Border Background="{ThemeResource LayerFillColorDefaultBrush}"
+              BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+              BorderThickness="1"
+              CornerRadius="8"
+              Padding="16">
+        <StackPanel Spacing="8">
+          <TextBlock Text="Code Sample"
+                     Style="{ThemeResource SubtitleTextBlockStyle}" />
+
+          <TextBlock FontFamily="Consolas" TextWrapping="Wrap">
+            <Run>using MZikmund.Toolkit.WinUI.Data;</Run><LineBreak />
+            <LineBreak />
+            <Run>public sealed class AppDb : SqliteDataServiceBase</Run><LineBreak />
+            <Run>{</Run><LineBreak />
+            <Run>    public AppDb(string path) : base(path) { }</Run><LineBreak />
+            <Run>    protected override IMigrationRunner CreateMigrationRunner() =&gt;</Run><LineBreak />
+            <Run>        new UserVersionMigrationRunner(new[]</Run><LineBreak />
+            <Run>        {</Run><LineBreak />
+            <Run>            async c =&gt; await c.ExecuteAsync("CREATE TABLE Reminder (Id INTEGER PRIMARY KEY, Title TEXT)"),</Run><LineBreak />
+            <Run>        });</Run><LineBreak />
+            <Run>}</Run>
+          </TextBlock>
+        </StackPanel>
+      </Border>
+    </StackPanel>
+  </ScrollViewer>
+</Page>

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/SqliteSamplePage.xaml.cs
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Pages/SqliteSamplePage.xaml.cs
@@ -1,0 +1,90 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using MZikmund.Toolkit.WinUI.Data;
+using SQLite;
+
+namespace MZikmund.Toolkit.Sample;
+
+public sealed partial class SqliteSamplePage : Page
+{
+    private DemoDb? _db;
+
+    public SqliteSamplePage()
+    {
+        this.InitializeComponent();
+    }
+
+    private async void Init_Click(object sender, RoutedEventArgs e)
+    {
+        _db ??= new DemoDb(":memory:");
+        var connection = await _db.EnsureInitializedAsync();
+        var version = await connection.ExecuteScalarAsync<int>("PRAGMA user_version");
+        SchemaVersionText.Text = $"Initialized. PRAGMA user_version = {version}";
+    }
+
+    private async void Insert_Click(object sender, RoutedEventArgs e)
+    {
+        if (_db is null)
+        {
+            ResultsText.Text = "Click Initialize first.";
+            return;
+        }
+
+        var connection = await _db.EnsureInitializedAsync();
+        var reminder = new Reminder
+        {
+            Title = TitleInput.Text,
+            DueAtTicks = DateTime.UtcNow.AddHours(Random.Shared.Next(-12, 12)).Ticks,
+        };
+        await connection.InsertAsync(reminder);
+        ResultsText.Text = $"Inserted: {reminder.Title} due {new DateTime(reminder.DueAtTicks):O}";
+    }
+
+    private async void QueryToday_Click(object sender, RoutedEventArgs e)
+    {
+        if (_db is null)
+        {
+            ResultsText.Text = "Click Initialize first.";
+            return;
+        }
+
+        var connection = await _db.EnsureInitializedAsync();
+        var today = DateTime.UtcNow.Date;
+        var range = DateRange.Between(today, today.AddDays(1).AddTicks(-1));
+        var rows = await connection.Table<Reminder>()
+            .Where(r => r.DueAtTicks >= range.FromTicks && r.DueAtTicks <= range.ToTicks)
+            .OrderBy(r => r.DueAtTicks)
+            .ToListAsync();
+
+        ResultsText.Text = rows.Count == 0
+            ? "No reminders today."
+            : string.Join("\n", rows.Select(r => $"#{r.Id} {new DateTime(r.DueAtTicks):HH:mm:ss}  {r.Title}"));
+    }
+
+    private sealed class DemoDb : SqliteDataServiceBase
+    {
+        public DemoDb(string path) : base(path)
+        {
+        }
+
+        protected override IMigrationRunner CreateMigrationRunner() =>
+            new UserVersionMigrationRunner(new Func<SQLiteAsyncConnection, Task>[]
+            {
+                static async c => await c.ExecuteAsync(
+                    "CREATE TABLE Reminder (Id INTEGER PRIMARY KEY AUTOINCREMENT, Title TEXT NOT NULL)"),
+                static async c => await c.ExecuteAsync(
+                    "ALTER TABLE Reminder ADD COLUMN DueAtTicks INTEGER NOT NULL DEFAULT 0"),
+            });
+    }
+
+    public sealed class Reminder
+    {
+        [PrimaryKey, AutoIncrement]
+        public int Id { get; set; }
+
+        public string Title { get; set; } = string.Empty;
+
+        [Indexed]
+        public long DueAtTicks { get; set; }
+    }
+}

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml
@@ -18,6 +18,8 @@
       <NavigationViewItemHeader Content="Extensions" />
       <NavigationViewItem Content="Package Version" Tag="PackageVersion" Icon="Document" />
       <NavigationViewItem Content="ObservableCollection Merge" Tag="ObservableCollectionMerge" Icon="List" />
+      <NavigationViewItemHeader Content="Data" />
+      <NavigationViewItem Content="SQLite Data Service" Tag="Sqlite" Icon="Save" />
       <NavigationViewItemHeader Content="Infrastructure" />
       <NavigationViewItem Content="XamlRoot Provider" Tag="XamlRootProvider" Icon="Page" />
     </NavigationView.MenuItems>

--- a/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml.cs
+++ b/samples/MZikmund.Toolkit.Sample/MZikmund.Toolkit.Sample/Shell.xaml.cs
@@ -30,6 +30,7 @@ public sealed partial class Shell : Page
                 "DialogCoordinator" => typeof(DialogCoordinatorSamplePage),
                 "PackageVersion" => typeof(PackageVersionSamplePage),
                 "ObservableCollectionMerge" => typeof(ObservableCollectionMergeSamplePage),
+                "Sqlite" => typeof(SqliteSamplePage),
                 "XamlRootProvider" => typeof(XamlRootProviderSamplePage),
                 _ => null
             };

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -3,5 +3,6 @@
   </ItemGroup>
   <ItemGroup>
 	<PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+	<PackageVersion Include="sqlite-net-pcl" Version="1.9.172" />
   </ItemGroup>
 </Project>

--- a/src/MZikmund.Toolkit.WinUI/Data/Sqlite/DateRange.cs
+++ b/src/MZikmund.Toolkit.WinUI/Data/Sqlite/DateRange.cs
@@ -1,0 +1,43 @@
+namespace MZikmund.Toolkit.WinUI.Data;
+
+/// <summary>
+/// Inclusive date range expressed as sortable <see cref="DateTime.Ticks"/> values.
+/// Designed for SQLite tables that store timestamps as <c>INTEGER</c> ticks: those
+/// columns are cheap to <c>BETWEEN ? AND ?</c> against and use the standard B-tree
+/// index without expression-based lookups.
+/// </summary>
+/// <param name="FromTicks">Inclusive lower bound, in <see cref="DateTime.Ticks"/> form.</param>
+/// <param name="ToTicks">Inclusive upper bound, in <see cref="DateTime.Ticks"/> form.</param>
+/// <example>
+/// <code>
+/// var range = DateRange.Between(weekStartLocal, weekEndLocal);
+/// var rows = await connection.Table&lt;Reminder&gt;()
+///     .Where(r =&gt; r.DueAtTicks &gt;= range.FromTicks &amp;&amp; r.DueAtTicks &lt;= range.ToTicks)
+///     .ToListAsync();
+/// </code>
+/// </example>
+public readonly record struct DateRange(long FromTicks, long ToTicks)
+{
+    /// <summary>
+    /// Builds a <see cref="DateRange"/> from two <see cref="DateTime"/> bounds. Order is
+    /// auto-corrected — passing <c>(end, start)</c> produces the same range as
+    /// <c>(start, end)</c>.
+    /// </summary>
+    public static DateRange Between(DateTime from, DateTime to)
+    {
+        var (lo, hi) = from <= to ? (from, to) : (to, from);
+        return new DateRange(lo.Ticks, hi.Ticks);
+    }
+
+    /// <summary>The lower bound as a <see cref="DateTime"/>.</summary>
+    public DateTime From => new(FromTicks);
+
+    /// <summary>The upper bound as a <see cref="DateTime"/>.</summary>
+    public DateTime To => new(ToTicks);
+
+    /// <summary>The duration of the range.</summary>
+    public TimeSpan Duration => To - From;
+
+    /// <summary>Returns <see langword="true"/> when <paramref name="ticks"/> falls within the range (inclusive).</summary>
+    public bool Contains(long ticks) => ticks >= FromTicks && ticks <= ToTicks;
+}

--- a/src/MZikmund.Toolkit.WinUI/Data/Sqlite/IMigrationRunner.cs
+++ b/src/MZikmund.Toolkit.WinUI/Data/Sqlite/IMigrationRunner.cs
@@ -1,0 +1,18 @@
+using SQLite;
+
+namespace MZikmund.Toolkit.WinUI.Data;
+
+/// <summary>
+/// Runs idempotent SQLite schema migrations against an open
+/// <see cref="SQLiteAsyncConnection"/>. Implementations decide how to track which
+/// migrations have already been applied — typical strategies are
+/// <c>PRAGMA user_version</c> (see <see cref="UserVersionMigrationRunner"/>) or a
+/// dedicated <c>__migrations</c> table.
+/// </summary>
+public interface IMigrationRunner
+{
+    /// <summary>
+    /// Applies all pending migrations and returns the resulting schema version.
+    /// </summary>
+    Task<int> RunAsync(SQLiteAsyncConnection connection);
+}

--- a/src/MZikmund.Toolkit.WinUI/Data/Sqlite/SqliteBatch.cs
+++ b/src/MZikmund.Toolkit.WinUI/Data/Sqlite/SqliteBatch.cs
@@ -1,0 +1,55 @@
+namespace MZikmund.Toolkit.WinUI.Data;
+
+/// <summary>
+/// Helpers for staying under SQLite's parameter cap when running an
+/// <c>IN (?, ?, ?, …)</c> or batched-insert query against a large input set.
+/// SQLite limits <c>SQLITE_MAX_VARIABLE_NUMBER</c> to <strong>32766</strong> on
+/// 3.32+ (and <strong>999</strong> on older versions).
+/// </summary>
+public static class SqliteBatch
+{
+    /// <summary>SQLite's default parameter cap on 3.32+ (32766).</summary>
+    public const int DefaultParameterLimit = 32766;
+
+    /// <summary>SQLite's parameter cap on versions older than 3.32 (999).</summary>
+    public const int LegacyParameterLimit = 999;
+
+    /// <summary>
+    /// Splits <paramref name="items"/> into chunks no larger than
+    /// <c>parameterLimit / parametersPerItem</c> (with a floor of 1). Pass
+    /// <paramref name="parametersPerItem"/> &gt; 1 when each item contributes more
+    /// than one bound parameter (e.g. an upsert with two columns per row).
+    /// </summary>
+    /// <param name="items">Source sequence to chunk.</param>
+    /// <param name="parametersPerItem">Bound parameters each item contributes (default 1).</param>
+    /// <param name="parameterLimit">Hard parameter cap (default <see cref="DefaultParameterLimit"/>).</param>
+    /// <returns>An enumerable of chunks suitable for executing in separate queries / transactions.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="items"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">A non-positive value was supplied for either limit.</exception>
+    public static IEnumerable<IReadOnlyList<T>> Chunk<T>(
+        IEnumerable<T> items,
+        int parametersPerItem = 1,
+        int parameterLimit = DefaultParameterLimit)
+    {
+        ArgumentNullException.ThrowIfNull(items);
+        ArgumentOutOfRangeException.ThrowIfLessThan(parametersPerItem, 1);
+        ArgumentOutOfRangeException.ThrowIfLessThan(parameterLimit, 1);
+
+        var chunkSize = Math.Max(1, parameterLimit / parametersPerItem);
+        var current = new List<T>(chunkSize);
+        foreach (var item in items)
+        {
+            current.Add(item);
+            if (current.Count == chunkSize)
+            {
+                yield return current;
+                current = new List<T>(chunkSize);
+            }
+        }
+
+        if (current.Count > 0)
+        {
+            yield return current;
+        }
+    }
+}

--- a/src/MZikmund.Toolkit.WinUI/Data/Sqlite/SqliteDataServiceBase.cs
+++ b/src/MZikmund.Toolkit.WinUI/Data/Sqlite/SqliteDataServiceBase.cs
@@ -1,0 +1,88 @@
+using SQLite;
+
+namespace MZikmund.Toolkit.WinUI.Data;
+
+/// <summary>
+/// Base class for app-specific SQLite data services. Lazy-initializes a
+/// <see cref="SQLiteAsyncConnection"/>, runs the <see cref="IMigrationRunner"/>,
+/// and exposes the connection through <see cref="EnsureInitializedAsync"/>.
+/// </summary>
+/// <remarks>
+/// Initialization is single-threaded via <see cref="SemaphoreSlim"/> — the first
+/// caller drives initialization, concurrent callers wait, and subsequent callers
+/// take a fast path that skips the lock.
+/// </remarks>
+public abstract class SqliteDataServiceBase : IAsyncDisposable
+{
+    private readonly string _databasePath;
+    private readonly SemaphoreSlim _initLock = new(1, 1);
+    private SQLiteAsyncConnection? _connection;
+
+    /// <summary>Initializes a new instance.</summary>
+    /// <param name="databasePath">Filesystem path of the SQLite database file (or <c>":memory:"</c>).</param>
+    protected SqliteDataServiceBase(string databasePath)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(databasePath);
+        _databasePath = databasePath;
+    }
+
+    /// <summary>The path passed to the constructor.</summary>
+    public string DatabasePath => _databasePath;
+
+    /// <summary>
+    /// Returns the initialized connection, creating it (and running migrations) on first call.
+    /// </summary>
+    public async Task<SQLiteAsyncConnection> EnsureInitializedAsync()
+    {
+        if (_connection is not null)
+        {
+            return _connection;
+        }
+
+        await _initLock.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            if (_connection is null)
+            {
+                var connection = new SQLiteAsyncConnection(_databasePath);
+                await OnConfiguringAsync(connection).ConfigureAwait(false);
+                var runner = CreateMigrationRunner();
+                if (runner is not null)
+                {
+                    await runner.RunAsync(connection).ConfigureAwait(false);
+                }
+                _connection = connection;
+            }
+
+            return _connection;
+        }
+        finally
+        {
+            _initLock.Release();
+        }
+    }
+
+    /// <summary>
+    /// Called immediately after the connection is created and before migrations run.
+    /// Override to apply pragmas, register custom collations, etc. Default is a no-op.
+    /// </summary>
+    protected virtual Task OnConfiguringAsync(SQLiteAsyncConnection connection) =>
+        Task.CompletedTask;
+
+    /// <summary>
+    /// Returns the migration runner that will populate / upgrade the schema, or
+    /// <see langword="null"/> if no migrations are needed (typically only for tests).
+    /// </summary>
+    protected abstract IMigrationRunner? CreateMigrationRunner();
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        if (_connection is { } connection)
+        {
+            await connection.CloseAsync().ConfigureAwait(false);
+        }
+        _initLock.Dispose();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/src/MZikmund.Toolkit.WinUI/Data/Sqlite/UserVersionMigrationRunner.cs
+++ b/src/MZikmund.Toolkit.WinUI/Data/Sqlite/UserVersionMigrationRunner.cs
@@ -1,0 +1,54 @@
+using SQLite;
+
+namespace MZikmund.Toolkit.WinUI.Data;
+
+/// <summary>
+/// <see cref="IMigrationRunner"/> that tracks the applied schema version through
+/// SQLite's built-in <c>PRAGMA user_version</c>. Migrations are an ordered list —
+/// each entry's index in the list is its target version. The runner advances
+/// <c>user_version</c> step-by-step and skips migrations whose index is &lt;= the
+/// stored version.
+/// </summary>
+/// <example>
+/// <code>
+/// var runner = new UserVersionMigrationRunner(new[]
+/// {
+///     async c => await c.ExecuteAsync("CREATE TABLE Reminder (Id INTEGER PRIMARY KEY, Title TEXT)"),
+///     async c => await c.ExecuteAsync("ALTER TABLE Reminder ADD COLUMN DueAt INTEGER"),
+/// });
+/// var version = await runner.RunAsync(connection);
+/// </code>
+/// </example>
+public sealed class UserVersionMigrationRunner : IMigrationRunner
+{
+    private readonly IReadOnlyList<Func<SQLiteAsyncConnection, Task>> _migrations;
+
+    /// <summary>Initializes a new instance with the supplied ordered migration list.</summary>
+    /// <param name="migrations">
+    /// Ordered list of migration delegates. The number of entries determines the target
+    /// schema version — fresh databases are upgraded all the way to <c>migrations.Count</c>.
+    /// </param>
+    public UserVersionMigrationRunner(IReadOnlyList<Func<SQLiteAsyncConnection, Task>> migrations)
+    {
+        ArgumentNullException.ThrowIfNull(migrations);
+        _migrations = migrations;
+    }
+
+    /// <summary>The target schema version (count of migrations).</summary>
+    public int TargetVersion => _migrations.Count;
+
+    /// <inheritdoc />
+    public async Task<int> RunAsync(SQLiteAsyncConnection connection)
+    {
+        ArgumentNullException.ThrowIfNull(connection);
+
+        var current = await connection.ExecuteScalarAsync<int>("PRAGMA user_version");
+        for (var i = current; i < _migrations.Count; i++)
+        {
+            await _migrations[i](connection);
+            await connection.ExecuteAsync($"PRAGMA user_version = {i + 1}");
+        }
+
+        return _migrations.Count;
+    }
+}

--- a/src/MZikmund.Toolkit.WinUI/MZikmund.Toolkit.WinUI.csproj
+++ b/src/MZikmund.Toolkit.WinUI/MZikmund.Toolkit.WinUI.csproj
@@ -41,6 +41,10 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="sqlite-net-pcl" />
+  </ItemGroup>
+
   <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">
     <!--
     If you encounter this error message:

--- a/tests/MZikmund.Toolkit.WinUI.Tests/SqliteDataTests.cs
+++ b/tests/MZikmund.Toolkit.WinUI.Tests/SqliteDataTests.cs
@@ -1,0 +1,263 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MZikmund.Toolkit.WinUI.Data;
+using SQLite;
+
+namespace MZikmund.Toolkit.WinUI.Tests;
+
+[TestClass]
+public class SqliteBatchTests
+{
+    [TestMethod]
+    public void Chunk_NullItems_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => SqliteBatch.Chunk<int>(null!).ToList());
+    }
+
+    [TestMethod]
+    public void Chunk_NonPositivePerItem_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => SqliteBatch.Chunk(new[] { 1 }, parametersPerItem: 0).ToList());
+    }
+
+    [TestMethod]
+    public void Chunk_NonPositiveLimit_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => SqliteBatch.Chunk(new[] { 1 }, parameterLimit: 0).ToList());
+    }
+
+    [TestMethod]
+    public void Chunk_DefaultLimit_RespectsCap()
+    {
+        var input = Enumerable.Range(0, 70_000).ToArray();
+
+        var chunks = SqliteBatch.Chunk(input).ToList();
+
+        // 70000 / 32766 = 2 full + remainder ⇒ 3 chunks total
+        Assert.AreEqual(3, chunks.Count);
+        Assert.AreEqual(SqliteBatch.DefaultParameterLimit, chunks[0].Count);
+        Assert.AreEqual(SqliteBatch.DefaultParameterLimit, chunks[1].Count);
+        Assert.AreEqual(70_000 - 2 * SqliteBatch.DefaultParameterLimit, chunks[2].Count);
+    }
+
+    [TestMethod]
+    public void Chunk_WithMultipleParametersPerItem_HalvesChunkSize()
+    {
+        var input = Enumerable.Range(0, 5_000).ToArray();
+
+        var chunks = SqliteBatch.Chunk(input, parametersPerItem: 2, parameterLimit: 100).ToList();
+
+        // 100 / 2 = 50 per chunk ⇒ 5000 / 50 = 100 chunks
+        Assert.AreEqual(100, chunks.Count);
+        Assert.IsTrue(chunks.All(c => c.Count == 50));
+    }
+
+    [TestMethod]
+    public void Chunk_EmptyInput_YieldsNothing()
+    {
+        Assert.AreEqual(0, SqliteBatch.Chunk(Array.Empty<int>()).Count());
+    }
+
+    [TestMethod]
+    public void Chunk_PreservesOrderAndContent()
+    {
+        var input = Enumerable.Range(0, 250).ToArray();
+
+        var chunks = SqliteBatch.Chunk(input, parameterLimit: 100).ToList();
+        var flattened = chunks.SelectMany(c => c).ToArray();
+
+        CollectionAssert.AreEqual(input, flattened);
+    }
+}
+
+[TestClass]
+public class DateRangeTests
+{
+    [TestMethod]
+    public void Between_OrdersBoundaries()
+    {
+        var start = new DateTime(2024, 1, 10, 0, 0, 0, DateTimeKind.Utc);
+        var end = new DateTime(2024, 1, 12, 0, 0, 0, DateTimeKind.Utc);
+
+        var direct = DateRange.Between(start, end);
+        var reversed = DateRange.Between(end, start);
+
+        Assert.AreEqual(direct, reversed);
+    }
+
+    [TestMethod]
+    public void From_To_RoundTripTicks()
+    {
+        var range = DateRange.Between(
+            new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            new DateTime(2024, 1, 31, 23, 59, 59, DateTimeKind.Utc));
+
+        Assert.AreEqual(new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc), range.From);
+        Assert.AreEqual(new DateTime(2024, 1, 31, 23, 59, 59, DateTimeKind.Utc), range.To);
+    }
+
+    [TestMethod]
+    public void Duration_ReturnsSpanBetweenBounds()
+    {
+        var range = DateRange.Between(
+            new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            new DateTime(2024, 1, 4, 0, 0, 0, DateTimeKind.Utc));
+
+        Assert.AreEqual(TimeSpan.FromDays(3), range.Duration);
+    }
+
+    [TestMethod]
+    public void Contains_InclusiveBounds()
+    {
+        var range = DateRange.Between(
+            new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            new DateTime(2024, 1, 3, 0, 0, 0, DateTimeKind.Utc));
+
+        Assert.IsTrue(range.Contains(range.FromTicks));
+        Assert.IsTrue(range.Contains(range.ToTicks));
+        Assert.IsTrue(range.Contains(new DateTime(2024, 1, 2).Ticks));
+        Assert.IsFalse(range.Contains(new DateTime(2023, 12, 31).Ticks));
+        Assert.IsFalse(range.Contains(new DateTime(2024, 1, 4).Ticks));
+    }
+}
+
+[TestClass]
+public class UserVersionMigrationRunnerTests
+{
+    [TestMethod]
+    public void Ctor_NullMigrations_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => new UserVersionMigrationRunner(null!));
+    }
+
+    [TestMethod]
+    public async Task RunAsync_FreshDatabase_RunsAllMigrationsAndReportsTargetVersion()
+    {
+        var connection = new SQLiteAsyncConnection(":memory:");
+        try
+        {
+            var runner = new UserVersionMigrationRunner(new Func<SQLiteAsyncConnection, Task>[]
+            {
+                static async c => await c.ExecuteAsync(
+                    "CREATE TABLE Foo (Id INTEGER PRIMARY KEY)"),
+                static async c => await c.ExecuteAsync(
+                    "ALTER TABLE Foo ADD COLUMN Name TEXT"),
+            });
+
+            var version = await runner.RunAsync(connection);
+
+            Assert.AreEqual(2, version);
+            Assert.AreEqual(2, await connection.ExecuteScalarAsync<int>("PRAGMA user_version"));
+        }
+        finally
+        {
+            await connection.CloseAsync();
+        }
+    }
+
+    [TestMethod]
+    public async Task RunAsync_AlreadyAtTarget_DoesNotReapply()
+    {
+        var connection = new SQLiteAsyncConnection(":memory:");
+        try
+        {
+            var ran = 0;
+            var runner = new UserVersionMigrationRunner(new Func<SQLiteAsyncConnection, Task>[]
+            {
+                async c =>
+                {
+                    ran++;
+                    await c.ExecuteAsync("CREATE TABLE Foo (Id INTEGER PRIMARY KEY)");
+                },
+            });
+
+            await runner.RunAsync(connection);
+            Assert.AreEqual(1, ran);
+
+            await runner.RunAsync(connection);
+            Assert.AreEqual(1, ran, "Migration should not re-run when user_version matches the target.");
+        }
+        finally
+        {
+            await connection.CloseAsync();
+        }
+    }
+
+    [TestMethod]
+    public async Task RunAsync_AdvancesUserVersionIncrementallyOnFailure()
+    {
+        var connection = new SQLiteAsyncConnection(":memory:");
+        try
+        {
+            var runner = new UserVersionMigrationRunner(new Func<SQLiteAsyncConnection, Task>[]
+            {
+                static async c => await c.ExecuteAsync("CREATE TABLE Foo (Id INTEGER PRIMARY KEY)"),
+                static c => throw new InvalidOperationException("boom"),
+            });
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() => runner.RunAsync(connection));
+
+            // First migration's PRAGMA write committed; second never ran.
+            Assert.AreEqual(1, await connection.ExecuteScalarAsync<int>("PRAGMA user_version"));
+        }
+        finally
+        {
+            await connection.CloseAsync();
+        }
+    }
+}
+
+[TestClass]
+public class SqliteDataServiceBaseTests
+{
+    [TestMethod]
+    public void Ctor_NullOrEmptyPath_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => new TestDb(string.Empty));
+        Assert.Throws<ArgumentException>(() => new TestDb(null!));
+    }
+
+    [TestMethod]
+    public async Task EnsureInitializedAsync_RunsMigrationsOnFirstCall()
+    {
+        await using var db = new TestDb(":memory:");
+
+        var connection = await db.EnsureInitializedAsync();
+
+        Assert.AreEqual(1, await connection.ExecuteScalarAsync<int>("PRAGMA user_version"));
+    }
+
+    [TestMethod]
+    public async Task EnsureInitializedAsync_SubsequentCalls_ReturnSameInstance()
+    {
+        await using var db = new TestDb(":memory:");
+
+        var first = await db.EnsureInitializedAsync();
+        var second = await db.EnsureInitializedAsync();
+
+        Assert.AreSame(first, second);
+    }
+
+    [TestMethod]
+    public async Task DatabasePath_ReflectsConstructorArgument()
+    {
+        await using var db = new TestDb(":memory:");
+
+        Assert.AreEqual(":memory:", db.DatabasePath);
+    }
+
+    private sealed class TestDb : SqliteDataServiceBase
+    {
+        public TestDb(string path) : base(path)
+        {
+        }
+
+        protected override IMigrationRunner? CreateMigrationRunner() =>
+            new UserVersionMigrationRunner(new Func<SQLiteAsyncConnection, Task>[]
+            {
+                static async c => await c.ExecuteAsync(
+                    "CREATE TABLE Item (Id INTEGER PRIMARY KEY)"),
+            });
+    }
+}


### PR DESCRIPTION
## Summary

Adds the SQLite data-access toolkit described in #27 under `MZikmund.Toolkit.WinUI.Data`:

- **`SqliteDataServiceBase`** — abstract base. Lazy-initializes a `SQLiteAsyncConnection` (single-threaded via `SemaphoreSlim`), invokes `OnConfiguringAsync`, runs the `IMigrationRunner` returned from `CreateMigrationRunner`, and exposes the connection through `EnsureInitializedAsync`. Implements `IAsyncDisposable`.
- **`IMigrationRunner`** — abstraction with `Task<int> RunAsync(SQLiteAsyncConnection)` that returns the resulting schema version.
- **`UserVersionMigrationRunner`** — tracks applied version through `PRAGMA user_version`. Each migration index is its target version; on a fresh database all migrations run, on an upgraded database only the new ones do. `user_version` advances after **each** successful migration so a partial-failure mid-batch resumes correctly on the next attempt.
- **`SqliteBatch.Chunk`** — slices a sequence under SQLite's 32766-parameter cap (constants for both modern `DefaultParameterLimit = 32766` and `LegacyParameterLimit = 999`). `parametersPerItem` multiplier handles batched inserts that bind multiple columns per row.
- **`DateRange`** — `readonly record struct` with inclusive ticks-based bounds. `Between(from, to)` auto-orders. Designed for tables that store timestamps as `INTEGER` ticks for cheap indexed `BETWEEN` queries: `r.DueAtTicks >= range.FromTicks && r.DueAtTicks <= range.ToTicks` uses the same B-tree index as the underlying column.

### Structural change

- Adds `sqlite-net-pcl 1.9.172` to `src/Directory.Packages.props` (Central Package Management).
- References it from `MZikmund.Toolkit.WinUI.csproj` so consumers transitively get the SQLite types when they reference the toolkit.

Wires a gallery sample (`SqliteSamplePage`) with a `DemoDb : SqliteDataServiceBase` against `":memory:"`. Two migrations (CREATE `Reminder`, ALTER ADD `DueAtTicks`) are run on init; Insert button writes random reminders; Query (today) reads via `DateRange.Between(today, today + 1 day)`.

Adds 17 unit tests against in-memory SQLite covering:
- `SqliteBatch.Chunk` null / non-positive arg guards, default-cap chunking on a 70 000-item input, multi-parameter halving, empty input, order preservation across chunks.
- `DateRange.Between` boundary auto-ordering, ticks round-trip, `Duration`, `Contains` inclusive bounds.
- `UserVersionMigrationRunner` null-arg, fresh-database all-run, idempotent re-run at target, and incremental commit on mid-batch failure.
- `SqliteDataServiceBase` argument guards, fresh-init runs migrations, repeated `EnsureInitializedAsync` returns the same connection instance, and `DatabasePath` reflects the constructor argument.

Closes #27

> Stacked on top of #56 (the `MergeWith` PR). Rebase on `main` once #56 merges.

## Test plan

- [x] `dotnet build MZikmund.Toolkit.slnx -c Debug` succeeds across all platforms.
- [x] Test exe reports 33/33 passed (14 prior + 19 new).
- [ ] Manually exercise the `SQLite Data Service` sample on Windows: click Initialize (status shows `PRAGMA user_version = 2`), click Insert a few times, click Query (today) — confirm the rows whose random `DueAtTicks` fell into today's range appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)